### PR TITLE
Feat: Implement BaseViewController and BaseView

### DIFF
--- a/ReminderProject/ReminderProject.xcodeproj/project.pbxproj
+++ b/ReminderProject/ReminderProject.xcodeproj/project.pbxproj
@@ -15,6 +15,9 @@
 		CED1E0872C33E8A2004BFBE1 /* .gitIgnore in Resources */ = {isa = PBXBuildFile; fileRef = CED1E0862C33E8A2004BFBE1 /* .gitIgnore */; };
 		CED1E08A2C33E968004BFBE1 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = CED1E0892C33E968004BFBE1 /* SnapKit */; };
 		CED1E08D2C33E989004BFBE1 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = CED1E08C2C33E989004BFBE1 /* RealmSwift */; };
+		CED1E0902C33EFE5004BFBE1 /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E08F2C33EFE5004BFBE1 /* BaseViewController.swift */; };
+		CED1E0922C33F056004BFBE1 /* BaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E0912C33F056004BFBE1 /* BaseView.swift */; };
+		CED1E0942C33F365004BFBE1 /* TestBaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E0932C33F365004BFBE1 /* TestBaseView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -26,6 +29,9 @@
 		CED1E07E2C33E79D004BFBE1 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		CED1E0802C33E79D004BFBE1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		CED1E0862C33E8A2004BFBE1 /* .gitIgnore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitIgnore; sourceTree = "<group>"; };
+		CED1E08F2C33EFE5004BFBE1 /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
+		CED1E0912C33F056004BFBE1 /* BaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseView.swift; sourceTree = "<group>"; };
+		CED1E0932C33F365004BFBE1 /* TestBaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestBaseView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -61,14 +67,25 @@
 		CED1E0712C33E79C004BFBE1 /* ReminderProject */ = {
 			isa = PBXGroup;
 			children = (
+				CED1E08E2C33EFD9004BFBE1 /* Bases */,
 				CED1E0722C33E79C004BFBE1 /* AppDelegate.swift */,
 				CED1E0742C33E79C004BFBE1 /* SceneDelegate.swift */,
 				CED1E0762C33E79C004BFBE1 /* ViewController.swift */,
 				CED1E07B2C33E79D004BFBE1 /* Assets.xcassets */,
 				CED1E07D2C33E79D004BFBE1 /* LaunchScreen.storyboard */,
 				CED1E0802C33E79D004BFBE1 /* Info.plist */,
+				CED1E0932C33F365004BFBE1 /* TestBaseView.swift */,
 			);
 			path = ReminderProject;
+			sourceTree = "<group>";
+		};
+		CED1E08E2C33EFD9004BFBE1 /* Bases */ = {
+			isa = PBXGroup;
+			children = (
+				CED1E08F2C33EFE5004BFBE1 /* BaseViewController.swift */,
+				CED1E0912C33F056004BFBE1 /* BaseView.swift */,
+			);
+			path = Bases;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -151,6 +168,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				CED1E0772C33E79C004BFBE1 /* ViewController.swift in Sources */,
+				CED1E0942C33F365004BFBE1 /* TestBaseView.swift in Sources */,
+				CED1E0902C33EFE5004BFBE1 /* BaseViewController.swift in Sources */,
+				CED1E0922C33F056004BFBE1 /* BaseView.swift in Sources */,
 				CED1E0732C33E79C004BFBE1 /* AppDelegate.swift in Sources */,
 				CED1E0752C33E79C004BFBE1 /* SceneDelegate.swift in Sources */,
 			);

--- a/ReminderProject/ReminderProject/Bases/BaseView.swift
+++ b/ReminderProject/ReminderProject/Bases/BaseView.swift
@@ -1,0 +1,46 @@
+//
+//  BaseView.swift
+//  ReminderProject
+//
+//  Created by user on 7/2/24.
+//
+
+import UIKit
+
+class BaseView: UIView {
+    weak var delegate: BaseViewDelegate?
+    
+    override init(frame: CGRect) {
+        super.init(frame: .zero)
+        
+        configureHierarchy()
+        configureLayout()
+        configureUI()
+        configureDelegate()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    internal func configureHierarchy() {
+        
+    }
+    
+    internal func configureLayout() {
+        
+    }
+    
+    internal func configureUI() {
+        self.backgroundColor = .white
+    }
+    
+    internal func configureDelegate() {
+//        delegate?.configureDelegate()
+    }
+}
+
+
+protocol BaseViewDelegate: BaseViewController {
+    func configureDelegate()
+}

--- a/ReminderProject/ReminderProject/Bases/BaseViewController.swift
+++ b/ReminderProject/ReminderProject/Bases/BaseViewController.swift
@@ -1,0 +1,59 @@
+//
+//  BaseViewController.swift
+//  ReminderProject
+//
+//  Created by user on 7/2/24.
+//
+
+import UIKit
+
+class BaseViewController: UIViewController {
+    private var baseView: BaseView! // force unwrapping 바꾸는 방법 생각해보기
+    
+    override func loadView() {
+        self.view = baseView
+    }
+    
+    required override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    convenience init(baseView: BaseView) {
+        self.init(nibName: nil, bundle: nil)
+        self.baseView = baseView
+    }
+    
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        configureHierarchy()
+        configureLayout()
+        configureUI()
+        configureDelegate()
+    }
+    
+    internal func configureHierarchy() {
+        
+    }
+    
+    internal func configureLayout() {
+        
+    }
+    
+    internal func configureUI() {
+        
+    }
+    
+    internal func configureDelegate() {
+        baseView.delegate = self
+    }
+}
+
+extension BaseViewController: BaseViewDelegate {
+    
+}

--- a/ReminderProject/ReminderProject/Bases/BaseViewController.swift
+++ b/ReminderProject/ReminderProject/Bases/BaseViewController.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 class BaseViewController: UIViewController {
-    private var baseView: BaseView! // force unwrapping 바꾸는 방법 생각해보기
+    private var baseView: BaseView? // force unwrapping 바꾸는 방법 생각해보기
     
     override func loadView() {
         self.view = baseView
@@ -50,7 +50,7 @@ class BaseViewController: UIViewController {
     }
     
     internal func configureDelegate() {
-        baseView.delegate = self
+        baseView?.delegate = self
     }
 }
 

--- a/ReminderProject/ReminderProject/SceneDelegate.swift
+++ b/ReminderProject/ReminderProject/SceneDelegate.swift
@@ -20,7 +20,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         window = UIWindow(windowScene: windowScene)
         
-        let rootViewController = ViewController()
+        let rootViewController = ViewController(baseView: TestBaseView())
         let navigationController = UINavigationController(rootViewController: rootViewController)
         window?.rootViewController = navigationController
         window?.makeKeyAndVisible()

--- a/ReminderProject/ReminderProject/TestBaseView.swift
+++ b/ReminderProject/ReminderProject/TestBaseView.swift
@@ -1,0 +1,17 @@
+//
+//  TestBaseView.swift
+//  ReminderProject
+//
+//  Created by user on 7/2/24.
+//
+
+import UIKit
+
+final class TestBaseView: BaseView {
+    
+    override func configureDelegate() {
+        super.configureDelegate()
+        
+        print(#function, "This is from TestBaseView")
+    }
+}

--- a/ReminderProject/ReminderProject/ViewController.swift
+++ b/ReminderProject/ReminderProject/ViewController.swift
@@ -7,15 +7,17 @@
 
 import UIKit
 
-class ViewController: UIViewController {
+final class ViewController: BaseViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
         
-        view.backgroundColor = .systemOrange
     }
 
-
+    override func configureUI() {
+        super.configureUI()
+        view.backgroundColor = .systemOrange
+    }
 }
 


### PR DESCRIPTION
## 🌱 *Pull requests*

🌿 **작업한 브랜치**
https://github.com/alpaka99/Reminder-Project/tree/%233/Feat/Implement-Base-Codes

<br></br>

## 🔍 **작업한 결과**
- BaseViewController와 BaseView를 사용하여 boiler plate를 줄이고, 일정한 규격을 갖추도록 하였습니다

<br></br>
## 🔫 **Trouble Shooting**
- ViewController를 초기화할때 자동으로 BaseView 타입의 뷰도 초기화해주고 싶었습니다.
- 그래서 ConfigureDelegate라는 메서드도 BaseViewController에 생성한 후에, baseView의 delegate를 자기자신으로 설정하는 코드를 구현하여 반복되는 코드를 더욱 줄이려고 노력하였습니다.

<br></br>
## 🔊 기타 공유사항
- 앞으로의 모든 View와 ViewController 관련 코드들에서는 BaseView와 BaseViewController를 사용하는게 목표입니다.
- configureDelegate() 메서드를 override할 경우, super.configureDelegate()를 해줍시다.
- BaseView를 optional로 안받는 방법을 생각해볼 수 있겠습니다.

<br></br>
## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
| 관련 이미지 |<img width="493" alt="image" src="https://github.com/alpaka99/Reminder-Project/assets/22471820/119fe3f5-31a9-4fd4-a51e-408e7e1a900e">|

<br></br>

## 📟 관련 이슈
- Resolved: #3 
