### PR TITLE
#8/feat/implement navigation

### DIFF
--- a/ReminderProject/ReminderProject.xcodeproj/project.pbxproj
+++ b/ReminderProject/ReminderProject.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		CED1E0B92C345386004BFBE1 /* ListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E0B82C345386004BFBE1 /* ListViewController.swift */; };
 		CED1E0BB2C34538B004BFBE1 /* ListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E0BA2C34538B004BFBE1 /* ListView.swift */; };
 		CED1E0BD2C34596B004BFBE1 /* ListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E0BC2C34596B004BFBE1 /* ListTableViewCell.swift */; };
+		CED1E0C02C346ABC004BFBE1 /* NavigationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E0BF2C346ABC004BFBE1 /* NavigationManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -60,6 +61,7 @@
 		CED1E0B82C345386004BFBE1 /* ListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListViewController.swift; sourceTree = "<group>"; };
 		CED1E0BA2C34538B004BFBE1 /* ListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListView.swift; sourceTree = "<group>"; };
 		CED1E0BC2C34596B004BFBE1 /* ListTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListTableViewCell.swift; sourceTree = "<group>"; };
+		CED1E0BF2C346ABC004BFBE1 /* NavigationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -95,6 +97,7 @@
 		CED1E0712C33E79C004BFBE1 /* ReminderProject */ = {
 			isa = PBXGroup;
 			children = (
+				CED1E0BE2C346AB5004BFBE1 /* Managers */,
 				CED1E0A52C3409CB004BFBE1 /* Extensions */,
 				CED1E0A22C3408C9004BFBE1 /* Protocols */,
 				CED1E09B2C33FEF4004BFBE1 /* Constants */,
@@ -186,6 +189,14 @@
 			path = ListView;
 			sourceTree = "<group>";
 		};
+		CED1E0BE2C346AB5004BFBE1 /* Managers */ = {
+			isa = PBXGroup;
+			children = (
+				CED1E0BF2C346ABC004BFBE1 /* NavigationManager.swift */,
+			);
+			path = Managers;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -267,6 +278,7 @@
 			files = (
 				CED1E0B42C341ED3004BFBE1 /* BaseTableViewCell.swift in Sources */,
 				CED1E0BB2C34538B004BFBE1 /* ListView.swift in Sources */,
+				CED1E0C02C346ABC004BFBE1 /* NavigationManager.swift in Sources */,
 				CED1E0982C33FA98004BFBE1 /* MainViewController.swift in Sources */,
 				CED1E09A2C33FAA9004BFBE1 /* MainView.swift in Sources */,
 				CED1E0A12C3405A9004BFBE1 /* BaseCollectionViewCell.swift in Sources */,

--- a/ReminderProject/ReminderProject/Managers/NavigationManager.swift
+++ b/ReminderProject/ReminderProject/Managers/NavigationManager.swift
@@ -1,0 +1,38 @@
+////
+////  NavigationManager.swift
+////  ReminderProject
+////
+////  Created by user on 7/3/24.
+////
+//
+import UIKit
+//
+final class NavigationManager {
+    static let shared = NavigationManager()
+    private(set) var navigationController = UINavigationController(rootViewController: MainViewController(baseView: MainView()))
+    
+    private init() { }
+    
+    internal func pushVC(_ vc: UIViewController, animated: Bool = true) {
+        navigationController.pushViewController(vc, animated: animated)
+    }
+    
+    internal func presentVC(_ vc: UIViewController, animated: Bool = true) {
+        navigationController.present(vc, animated: animated)
+    }
+    
+    internal func popVC(animated: Bool) {
+        navigationController.popViewController(animated: animated)
+    }
+    
+    internal func dismiss(animated: Bool) {
+        navigationController.dismiss(animated: true)
+    }
+    
+//    internal func replaceVC(_ vc: BaseViewController) {
+//        let navigationController = UINavigationController(rootViewController: vc)
+//        
+//        self.window?.rootViewController = navigationController
+//        window?.makeKeyAndVisible()
+//    }
+}

--- a/ReminderProject/ReminderProject/SceneDelegate.swift
+++ b/ReminderProject/ReminderProject/SceneDelegate.swift
@@ -16,13 +16,17 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
-        guard let windowScene = (scene as? UIWindowScene) else { return }
         
-        window = UIWindow(windowScene: windowScene)
+        guard let scene = (scene as? UIWindowScene) else { return }
+
+        window = UIWindow(windowScene: scene)
         
-        let rootViewController = ListViewController(baseView: ListView())
-        let navigationController = UINavigationController(rootViewController: rootViewController)
-        window?.rootViewController = navigationController
+//        let rootViewController = MainViewController(baseView: MainView())
+//        let navigationController = UINavigationController(rootViewController: rootViewController)
+        
+        
+        
+        window?.rootViewController = NavigationManager.shared.navigationController
         window?.makeKeyAndVisible()
     }
 

--- a/ReminderProject/ReminderProject/Views/ListView/ListViewController.swift
+++ b/ReminderProject/ReminderProject/Views/ListView/ListViewController.swift
@@ -8,7 +8,23 @@
 import UIKit
 
 final class ListViewController: BaseViewController {
+    private lazy var rightBarbutton = UIBarButtonItem(
+        image: UIImage(systemName: "ellipsis.circle"),
+        style: .plain,
+        target: self,
+        action: #selector(rightBarButtonTapped)
+    )
     
+    override func configureUI() {
+        super.configureUI()
+        
+        navigationItem.rightBarButtonItem = rightBarbutton
+    }
+    
+    @objc
+    func rightBarButtonTapped() {
+        
+    }
 }
 
 extension ListViewController: UITableViewDelegate, UITableViewDataSource {

--- a/ReminderProject/ReminderProject/Views/MainView/MainView.swift
+++ b/ReminderProject/ReminderProject/Views/MainView/MainView.swift
@@ -10,14 +10,55 @@ import UIKit
 import SnapKit
 
 final class MainView: BaseView {
-    let titleLabel = UILabel()
-    let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionView.flowLayout(spacing: 16, numberOfItemsInRow: 2, heightMultiplier: 0.5))
+    private let titleLabel = {
+        let label = UILabel()
+        label.text = "전체"
+        label.font = .systemFont(ofSize: 32, weight: .semibold)
+        label.textColor = .gray
+        return label
+    }()
+    
+    private let collectionView = {
+        let collectionView = UICollectionView(
+            frame: .zero,
+            collectionViewLayout: UICollectionView.flowLayout(
+                spacing: 16,
+                numberOfItemsInRow: 2,
+                heightMultiplier: 0.5
+            ))
+        collectionView.backgroundColor = .clear
+        
+        return collectionView
+    }()
+    
+    private let newTodoButton = {
+        let button = UIButton()
+        var config = UIButton.Configuration.plain()
+        config.image = UIImage(systemName: "plus.circle.fill")
+        config.title = "새로운 할 일"
+        config.imagePlacement = .leading
+        config.imagePadding = 8
+        button.configuration = config
+        
+        return button
+    }()
+    
+    private let addListButton = {
+        let button = UIButton()
+        var config = UIButton.Configuration.plain()
+        config.title = "목록 추가"
+        
+        button.configuration = config
+        return button
+    }()
     
     override func configureHierarchy() {
         super.configureHierarchy()
         
         self.addSubview(titleLabel)
         self.addSubview(collectionView)
+        self.addSubview(newTodoButton)
+        self.addSubview(addListButton)
     }
     
     
@@ -32,18 +73,37 @@ final class MainView: BaseView {
         collectionView.snp.makeConstraints {
             $0.top.equalTo(titleLabel.snp.bottom)
                 .offset(20)
-            $0.horizontalEdges.bottom.equalTo(self.safeAreaLayoutGuide)
+            $0.horizontalEdges.equalTo(self.safeAreaLayoutGuide)
+        }
+        
+        newTodoButton.snp.makeConstraints {
+            $0.top.equalTo(collectionView.snp.bottom)
+            $0.leading.equalTo(titleLabel.snp.leading)
+            $0.bottom.equalTo(self.safeAreaLayoutGuide)
+                .offset(-16)
+        }
+        
+        addListButton.snp.makeConstraints {
+            $0.top.equalTo(collectionView.snp.bottom)
+            $0.trailing.equalTo(titleLabel.snp.trailing)
+            $0.bottom.equalTo(self.safeAreaLayoutGuide)
+                .offset(-16)
         }
     }
     
     override func configureUI() {
         super.configureUI()
         
-        titleLabel.text = "전체"
-        titleLabel.font = .systemFont(ofSize: 32, weight: .semibold)
-        titleLabel.textColor = .gray
-        
-        collectionView.backgroundColor = .clear
+        newTodoButton.addTarget(
+            self,
+            action: #selector(newTodoButtonTapped),
+            for: .touchUpInside
+        )
+        addListButton.addTarget(
+            self,
+            action: #selector(addListButtonTapped),
+            for: .touchUpInside
+        )
     }
     
     override func configureDelegate(_ vc: BaseViewController?) {
@@ -54,5 +114,17 @@ final class MainView: BaseView {
         
         collectionView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: UICollectionViewCell.identifier)
         collectionView.register(MainCollectionViewCell.self, forCellWithReuseIdentifier: MainCollectionViewCell.identifier)
+    }
+    
+    @objc
+    func newTodoButtonTapped() {
+        let nextViewController = RegisterViewController(baseView: RegisterView())
+        let navigationController = UINavigationController(rootViewController: nextViewController)
+        NavigationManager.shared.presentVC(navigationController)
+    }
+    
+    @objc
+    func addListButtonTapped() {
+        NavigationManager.shared.pushVC(ListViewController(baseView: ListView()))
     }
 }

--- a/ReminderProject/ReminderProject/Views/MainView/MainViewController.swift
+++ b/ReminderProject/ReminderProject/Views/MainView/MainViewController.swift
@@ -8,7 +8,18 @@
 import UIKit
 
 final class MainViewController: BaseViewController {
-    let categories: [TodoCategory] = TodoCategory.allCases
+    private let categories: [TodoCategory] = TodoCategory.allCases
+    private lazy var rightBarbutton = UIBarButtonItem(image: UIImage(systemName: "ellipsis.circle"), style: .plain, target: self, action: #selector(rightBarButtonTapped))
+    
+    override func configureUI() {
+        super.configureUI()
+        
+        navigationItem.rightBarButtonItem = rightBarbutton
+    }
+    
+    @objc func rightBarButtonTapped() {
+        print(#function)
+    }
 }
 
 extension MainViewController: UICollectionViewDelegate, UICollectionViewDataSource {

--- a/ReminderProject/ReminderProject/Views/RegisterView/RegisterView.swift
+++ b/ReminderProject/ReminderProject/Views/RegisterView/RegisterView.swift
@@ -30,11 +30,14 @@ final class RegisterView: BaseView {
         
         stackView.snp.makeConstraints {
             $0.top.horizontalEdges.equalTo(self.safeAreaLayoutGuide)
+                .inset(16)
         }
     }
     
     override func configureUI() {
         super.configureUI()
+        
+        self.backgroundColor = UIColor(red: 0.1, green: 0.1, blue: 0.1, alpha: 1)
         
         stackView.backgroundColor = .clear
         stackView.axis = .vertical

--- a/ReminderProject/ReminderProject/Views/RegisterView/RegisterViewController.swift
+++ b/ReminderProject/ReminderProject/Views/RegisterView/RegisterViewController.swift
@@ -9,6 +9,45 @@ import UIKit
 
 final class RegisterViewController: BaseViewController {
     private let registerFieldTypes: [RegisterFieldType] = RegisterFieldType.allCases
+    
+    private lazy var leftBarButton = {
+        let barButton = UIBarButtonItem(
+            title: "취소",
+            style: .plain,
+            target: self,
+            action: #selector(cancelButtonTapped)
+        )
+        return barButton
+    }()
+    
+    private lazy var rightBarButton = {
+        let barButton = UIBarButtonItem(
+            title: "추가",
+            style: .plain,
+            target: self,
+            action: #selector(addButtonTapped)
+        )
+        barButton.isEnabled = false
+        return barButton
+    }()
+    
+    override func configureUI() {
+        super.configureUI()
+        
+        navigationItem.title = "새로운 할 일"
+        navigationItem.leftBarButtonItem = leftBarButton
+        navigationItem.rightBarButtonItem = rightBarButton
+    }
+    
+    @objc
+    func cancelButtonTapped() {
+        NavigationManager.shared.dismiss(animated: true)
+    }
+    
+    @objc
+    func addButtonTapped() {
+        print(#function)
+    }
 }
 
 extension RegisterViewController: UITextViewDelegate {


### PR DESCRIPTION
## 🌱 *Pull requests*

🌿 **작업한 브랜치**
https://github.com/alpaka99/Reminder-Project/tree/%238/Feat/Implement-Navigation

<br></br>

## 🔍 **작업한 결과**
- [x] Scenedelegate 설정을 통해 mainview를 가장 처음에 보여줍니다
- [x] navigation을 통해 적절한 뷰들로 이동할 수 있도록 합니다
- [x] viewController에 알맞은 navigation 버튼들을 달 수 있도록 합니다

<br></br>
## 🔫 **Trouble Shooting**
- View와 ViewController를 분리하고 나서 navigation 처리에 대한 고민이 많았습니다. 특히 `view에서 action이 일어나는 경우 viewController까지 delegate를 끌어다가 메서드를 실행시키는게 과연 올바른가?에 대한 고민`을 많이 했습니다.
- 그래서 `Navigation을 관리하는 Manager를 만들고 이 Manager를 싱글톤 패턴으로 구현`하였습니다. 그리고 대부분의 navigation 작업을 이 NavigationManager로부터 호출하는 방법을 사용하였습니다.
- 이로 인해 View에서도 Navigation 관련 작업을 하지 않고 단순히 호출만 하게 되었고, ViewController에서도 navigation 작업이 아닌, view를 관리하는 연산에 더 집중하도록 할 수 있게 되었습니다.
```swift
class NavigationManager {
    static let shared = NavigationManager()
}

class SomeView: UIView {
    // some view codes
    NavigationManager.shared.pushVC()
}

```


<br></br>
## 🔊 기타 공유사항
- 아직 NavigationManager가 완벽하게 구현되어있지는 않아서, 추후에 업데이트를 통해 더욱 좋은 구조를 만들어야겠습니다.

<br></br>
## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|NavigationManager를 통한 뷰 이동 구현|![Simulator Screen Recording - iPhone 15 Pro - 2024-07-03 at 03 48 26](https://github.com/alpaka99/Reminder-Project/assets/22471820/f7b2f5d4-ff95-41dd-9ac9-4521571dfb6d)|


## 📟 관련 이슈
- Resolved: #8 
