### PR TITLE
Feat: Implement Realm Manager and Apply to ViewController

### DIFF
--- a/ReminderProject/ReminderProject.xcodeproj/project.pbxproj
+++ b/ReminderProject/ReminderProject.xcodeproj/project.pbxproj
@@ -33,6 +33,9 @@
 		CED1E0BB2C34538B004BFBE1 /* ListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E0BA2C34538B004BFBE1 /* ListView.swift */; };
 		CED1E0BD2C34596B004BFBE1 /* ListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E0BC2C34596B004BFBE1 /* ListTableViewCell.swift */; };
 		CED1E0C02C346ABC004BFBE1 /* NavigationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E0BF2C346ABC004BFBE1 /* NavigationManager.swift */; };
+		CED1E0C22C34870D004BFBE1 /* RealmManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E0C12C34870D004BFBE1 /* RealmManager.swift */; };
+		CED1E0C62C348920004BFBE1 /* Todos.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E0C52C348920004BFBE1 /* Todos.swift */; };
+		CED1E0C82C3497E2004BFBE1 /* ViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E0C72C3497E2004BFBE1 /* ViewController+Extension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -62,6 +65,9 @@
 		CED1E0BA2C34538B004BFBE1 /* ListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListView.swift; sourceTree = "<group>"; };
 		CED1E0BC2C34596B004BFBE1 /* ListTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListTableViewCell.swift; sourceTree = "<group>"; };
 		CED1E0BF2C346ABC004BFBE1 /* NavigationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationManager.swift; sourceTree = "<group>"; };
+		CED1E0C12C34870D004BFBE1 /* RealmManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmManager.swift; sourceTree = "<group>"; };
+		CED1E0C52C348920004BFBE1 /* Todos.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Todos.swift; sourceTree = "<group>"; };
+		CED1E0C72C3497E2004BFBE1 /* ViewController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Extension.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -97,6 +103,7 @@
 		CED1E0712C33E79C004BFBE1 /* ReminderProject */ = {
 			isa = PBXGroup;
 			children = (
+				CED1E0C32C348913004BFBE1 /* Models */,
 				CED1E0BE2C346AB5004BFBE1 /* Managers */,
 				CED1E0A52C3409CB004BFBE1 /* Extensions */,
 				CED1E0A22C3408C9004BFBE1 /* Protocols */,
@@ -164,6 +171,7 @@
 			isa = PBXGroup;
 			children = (
 				CED1E0A62C3409D5004BFBE1 /* UICollectionViewCell+Extension.swift */,
+				CED1E0C72C3497E2004BFBE1 /* ViewController+Extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -193,8 +201,25 @@
 			isa = PBXGroup;
 			children = (
 				CED1E0BF2C346ABC004BFBE1 /* NavigationManager.swift */,
+				CED1E0C12C34870D004BFBE1 /* RealmManager.swift */,
 			);
 			path = Managers;
+			sourceTree = "<group>";
+		};
+		CED1E0C32C348913004BFBE1 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				CED1E0C42C348919004BFBE1 /* RealmModels */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		CED1E0C42C348919004BFBE1 /* RealmModels */ = {
+			isa = PBXGroup;
+			children = (
+				CED1E0C52C348920004BFBE1 /* Todos.swift */,
+			);
+			path = RealmModels;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -284,11 +309,14 @@
 				CED1E0A12C3405A9004BFBE1 /* BaseCollectionViewCell.swift in Sources */,
 				CED1E0AE2C34156B004BFBE1 /* RegisterView.swift in Sources */,
 				CED1E0902C33EFE5004BFBE1 /* BaseViewController.swift in Sources */,
+				CED1E0C82C3497E2004BFBE1 /* ViewController+Extension.swift in Sources */,
 				CED1E0A42C3408D0004BFBE1 /* Reusable.swift in Sources */,
 				CED1E0B62C342DD1004BFBE1 /* RegisterOpenedCell.swift in Sources */,
 				CED1E0BD2C34596B004BFBE1 /* ListTableViewCell.swift in Sources */,
+				CED1E0C62C348920004BFBE1 /* Todos.swift in Sources */,
 				CED1E0922C33F056004BFBE1 /* BaseView.swift in Sources */,
 				CED1E09F2C34059D004BFBE1 /* MainCollectionViewCell.swift in Sources */,
+				CED1E0C22C34870D004BFBE1 /* RealmManager.swift in Sources */,
 				CED1E0B02C341CDC004BFBE1 /* RegisterDisclosureCell.swift in Sources */,
 				CED1E0A92C340DEE004BFBE1 /* TodoCategory.swift in Sources */,
 				CED1E09D2C33FEF9004BFBE1 /* Constants.swift in Sources */,

--- a/ReminderProject/ReminderProject/Extensions/ViewController+Extension.swift
+++ b/ReminderProject/ReminderProject/Extensions/ViewController+Extension.swift
@@ -1,0 +1,26 @@
+//
+//  ViewController+Extension.swift
+//  ReminderProject
+//
+//  Created by user on 7/3/24.
+//
+
+import UIKit
+
+extension UIViewController {
+    func showAlert(title: String, message: String? = nil, action: @escaping ()->()) {
+        let ac = UIAlertController(
+            title: title,
+            message: message,
+            preferredStyle: .alert
+        )
+        
+        let action = UIAlertAction(title: "확인", style: .default) { _ in
+            action()
+        }
+        
+        ac.addAction(action)
+        
+        NavigationManager.shared.presentVC(ac, animated: true)
+    }
+}

--- a/ReminderProject/ReminderProject/Managers/RealmManager.swift
+++ b/ReminderProject/ReminderProject/Managers/RealmManager.swift
@@ -1,0 +1,72 @@
+//
+//  RealmManager.swift
+//  ReminderProject
+//
+//  Created by user on 7/3/24.
+//
+
+import RealmSwift
+
+final class RealmManager {
+    static let shared = RealmManager()
+    private var realm: Realm?
+    
+    private init() { 
+        
+        initializeRealm()
+    }
+    
+    private func initializeRealm() {
+        do {
+            self.realm = try Realm()
+        } catch {
+            print("Realm Initialize Error")
+            print(error)
+        }
+    }
+    
+    internal func create<T: Object>(_ data: T) {
+        do {
+            try realm?.write {
+                realm?.add(data)
+            }
+        } catch {
+            print("Realm Create error")
+            print(error.localizedDescription)
+        }
+    }
+    
+    internal func readAll<T: Object>(_ type: T.Type) -> Results<T>? {
+        let results = realm?.objects(type)
+        return results
+    }
+    
+    internal func readOne<T: Object>(_ data: T) -> T? {
+        let result = realm?.object(ofType: T.self, forPrimaryKey: data.objectSchema.primaryKeyProperty)
+        return result
+    }
+    
+    // MARK: Update
+    internal func update<T: Object> (with newValue: T) {
+        do {
+            let target = realm?.object(ofType: T.self, forPrimaryKey: newValue.objectSchema.primaryKeyProperty)
+            try realm?.write {
+                realm?.add(newValue, update: .modified)
+            }
+        } catch {
+            print("Realm Update Error")
+            print(error.localizedDescription)
+        }
+    }
+    
+    internal func delete<T: Object>(_ data: T) {
+        do {
+            try realm?.write {
+                realm?.delete(data)
+            }
+        } catch {
+            print("Realm Delete Error")
+            print(error.localizedDescription)
+        }
+    }
+}

--- a/ReminderProject/ReminderProject/Models/RealmModels/Todos.swift
+++ b/ReminderProject/ReminderProject/Models/RealmModels/Todos.swift
@@ -1,0 +1,32 @@
+//
+//  Todos.swift
+//  ReminderProject
+//
+//  Created by user on 7/3/24.
+//
+
+import Foundation
+
+import RealmSwift
+
+class Todos: Object {
+    @Persisted(primaryKey: true) var _id: ObjectId
+    @Persisted(indexed: true) var category: String
+    @Persisted var title: String
+    @Persisted var content: String?
+    @Persisted var createdAt: Date
+    
+    convenience init(
+        category: String,
+        title: String,
+        content: String? = nil,
+        createdAt: Date = Date.now
+    ) {
+        self.init()
+        
+        self.category = category
+        self.title = title
+        self.content = content
+        self.createdAt = createdAt
+    }
+}

--- a/ReminderProject/ReminderProject/Views/ListView/ListTableViewCell.swift
+++ b/ReminderProject/ReminderProject/Views/ListView/ListTableViewCell.swift
@@ -73,20 +73,27 @@ final class ListTableViewCell: BaseTableViewCell {
         
         toggleButton.setImage(UIImage(systemName: "circle"), for: .normal)
         
-        title.text = "키보드 구매"
+        
         title.font = .systemFont(ofSize: 16, weight: .semibold)
         title.textColor = .white
         
-        content.text = "예쁜 키캡 알아보기"
+        
         content.font = .systemFont(ofSize: 12, weight: .medium)
         content.textColor = .systemGray4
         
-        dateLabel.text = Date.now.formatted()
+        
         dateLabel.font = .systemFont(ofSize: 12, weight: .medium)
         dateLabel.textColor = .systemGray4
         
-        tagLabel.text = "#쇼핑"
+        
         tagLabel.font = .systemFont(ofSize: 12, weight: .semibold)
         tagLabel.textColor = .systemBlue
+    }
+    
+    func configureData(_ data: Todos) {
+        title.text = data.title
+        content.text = data.content
+        dateLabel.text = data.createdAt.formatted()
+        tagLabel.text = "#쇼핑"
     }
 }

--- a/ReminderProject/ReminderProject/Views/ListView/ListViewController.swift
+++ b/ReminderProject/ReminderProject/Views/ListView/ListViewController.swift
@@ -15,6 +15,8 @@ final class ListViewController: BaseViewController {
         action: #selector(rightBarButtonTapped)
     )
     
+    private var results = RealmManager.shared.readAll(Todos.self)
+    
     override func configureUI() {
         super.configureUI()
         
@@ -23,18 +25,35 @@ final class ListViewController: BaseViewController {
     
     @objc
     func rightBarButtonTapped() {
+        let ac = UIAlertController(title: "정렬", message: nil, preferredStyle: .actionSheet)
+        let dueDateSort = UIAlertAction(title: "날짜 순", style: .default) {[weak self] _ in
+            self?.results = self?.results?.sorted(byKeyPath: "createdAt", ascending: true)
+        }
+        let titleSort = UIAlertAction(title: "이름 순", style: .default) { [weak self] _ in
+            self?.results = self?.results?.sorted(byKeyPath: "title", ascending: true)
+        }
+        let memoSort = UIAlertAction(title: "메모 순", style: .default) { [weak self] _ in
+            self?.results = self?.results?.sorted(byKeyPath: "content", ascending: true)
+        }
         
+        ac.addAction(dueDateSort)
+        ac.addAction(titleSort)
+        ac.addAction(memoSort)
+        
+        NavigationManager.shared.presentVC(ac, animated: true)
     }
 }
 
 extension ListViewController: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 5
+        return results?.count ?? 0
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: ListTableViewCell.identifier, for: indexPath) as? ListTableViewCell else { return UITableViewCell() }
-        
+        if let data = results?[indexPath.row] {
+            cell.configureData(data)
+        }
         return cell
     }
     
@@ -44,5 +63,21 @@ extension ListViewController: UITableViewDelegate, UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return UITableView.automaticDimension
+    }
+    
+    func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        let target = results?[indexPath.row]
+        
+        let deleteAction = UIContextualAction(
+            style: .destructive,
+            title: "삭제"
+        ) { _, _, _ in
+            if let target = target {
+                RealmManager.shared.delete(target)
+                tableView.reloadData()
+            }
+        }
+        
+        return UISwipeActionsConfiguration(actions: [deleteAction])
     }
 }

--- a/ReminderProject/ReminderProject/Views/ListView/ListViewController.swift
+++ b/ReminderProject/ReminderProject/Views/ListView/ListViewController.swift
@@ -35,15 +35,40 @@ final class ListViewController: BaseViewController<ListView> {
     
     @objc
     func rightBarButtonTapped() {
-        let ac = UIAlertController(title: "정렬", message: nil, preferredStyle: .actionSheet)
-        let dueDateSort = UIAlertAction(title: "날짜 순", style: .default) {[weak self] _ in
-            self?.results = self?.results?.sorted(byKeyPath: "createdAt", ascending: true)
+        let ac = UIAlertController(
+            title: "정렬",
+            message: nil,
+            preferredStyle: .actionSheet
+        )
+        let dueDateSort = UIAlertAction(
+            title: "날짜 순",
+            style: .default
+        ) {[weak self] _ in
+            self?.results = self?.results?.sorted(
+                byKeyPath: "createdAt",
+                ascending: true
+            )
+            self?.baseView.tableView.reloadData()
         }
-        let titleSort = UIAlertAction(title: "이름 순", style: .default) { [weak self] _ in
-            self?.results = self?.results?.sorted(byKeyPath: "title", ascending: true)
+        let titleSort = UIAlertAction(
+            title: "이름 순",
+            style: .default
+        ) { [weak self] _ in
+            self?.results = self?.results?.sorted(
+                byKeyPath: "title",
+                ascending: true
+            )
+            self?.baseView.tableView.reloadData()
         }
-        let memoSort = UIAlertAction(title: "메모 순", style: .default) { [weak self] _ in
-            self?.results = self?.results?.sorted(byKeyPath: "content", ascending: true)
+        let memoSort = UIAlertAction(
+            title: "메모 순",
+            style: .default
+        ) { [weak self] _ in
+            self?.results = self?.results?.sorted(
+                byKeyPath: "content",
+                ascending: true
+            )
+            self?.baseView.tableView.reloadData()
         }
         
         ac.addAction(dueDateSort)

--- a/ReminderProject/ReminderProject/Views/MainView/MainViewController.swift
+++ b/ReminderProject/ReminderProject/Views/MainView/MainViewController.swift
@@ -9,7 +9,14 @@ import UIKit
 
 final class MainViewController: BaseViewController {
     private let categories: [TodoCategory] = TodoCategory.allCases
-    private lazy var rightBarbutton = UIBarButtonItem(image: UIImage(systemName: "ellipsis.circle"), style: .plain, target: self, action: #selector(rightBarButtonTapped))
+    
+    private lazy var rightBarbutton = UIBarButtonItem(
+        image: UIImage(systemName: "ellipsis.circle"),
+        style: .plain,
+        target: self,
+        action: #selector(rightBarButtonTapped)
+    )
+    
     
     override func configureUI() {
         super.configureUI()

--- a/ReminderProject/ReminderProject/Views/RegisterView/RegisterOpenedCell.swift
+++ b/ReminderProject/ReminderProject/Views/RegisterView/RegisterOpenedCell.swift
@@ -71,6 +71,7 @@ final class RegisterOpenedCell: BaseView {
     override func configureDelegate(_ vc: BaseViewController? = nil) {
         super.configureDelegate()
         
+        textField.delegate = vc as? any UITextFieldDelegate
         textView.delegate = vc as? any UITextViewDelegate
     }
 }

--- a/ReminderProject/ReminderProject/Views/RegisterView/RegisterOpenedCell.swift
+++ b/ReminderProject/ReminderProject/Views/RegisterView/RegisterOpenedCell.swift
@@ -10,9 +10,38 @@ import UIKit
 import SnapKit
 
 final class RegisterOpenedCell: BaseView {
-    private let textField = UITextField()
-    private let divider = UIView()
-    private let textView = UITextView()
+    let textField = {
+        let textField = UITextField()
+        
+        var attributedContainer = AttributeContainer()
+        attributedContainer.foregroundColor = .systemGray5
+        attributedContainer.font = .systemFont(ofSize: 20, weight: .semibold)
+        let attributedString = AttributedString("제목", attributes: attributedContainer)
+        textField.attributedPlaceholder = NSAttributedString(attributedString)
+        textField.textColor = .white
+        
+        return textField
+    }()
+    
+    private let divider = {
+        let view = UIView()
+        
+        view.backgroundColor = .systemGray5
+        
+        return view
+    }()
+    
+    let textView = {
+        let textView = UITextView()
+        
+        textView.backgroundColor = .darkGray
+        textView.text = "메모"
+        textView.textColor = .systemGray4
+        textView.font = .systemFont(ofSize: 18)
+        textView.textContainer.maximumNumberOfLines = 8
+        
+        return textView
+    }()
     
     override func configureHierarchy() {
         super.configureHierarchy()
@@ -51,20 +80,5 @@ final class RegisterOpenedCell: BaseView {
         
         self.backgroundColor = .darkGray
         self.layer.cornerRadius = 8
-        
-        var attributedContainer = AttributeContainer()
-        attributedContainer.foregroundColor = .systemGray5
-        attributedContainer.font = .systemFont(ofSize: 20, weight: .semibold)
-        let attributedString = AttributedString("제목", attributes: attributedContainer)
-        textField.attributedPlaceholder = NSAttributedString(attributedString)
-        textField.textColor = .white
-        
-        divider.backgroundColor = .systemGray5
-        
-        textView.backgroundColor = .darkGray
-        textView.text = "메모"
-        textView.textColor = .systemGray4
-        textView.font = .systemFont(ofSize: 18)
-        textView.textContainer.maximumNumberOfLines = 8
     }
 }

--- a/ReminderProject/ReminderProject/Views/RegisterView/RegisterView.swift
+++ b/ReminderProject/ReminderProject/Views/RegisterView/RegisterView.swift
@@ -9,7 +9,7 @@ import UIKit
 
 import SnapKit
 
-final class RegisterView: BaseView{
+final class RegisterView: BaseView {
     let memoView = RegisterOpenedCell()
     lazy var stackView = UIStackView()
     

--- a/ReminderProject/ReminderProject/Views/RegisterView/RegisterViewController.swift
+++ b/ReminderProject/ReminderProject/Views/RegisterView/RegisterViewController.swift
@@ -44,9 +44,36 @@ final class RegisterViewController: BaseViewController {
         NavigationManager.shared.dismiss(animated: true)
     }
     
+    // MARK: Fetch TextField from baseView
     @objc
     func addButtonTapped() {
-        print(#function)
+        RealmManager.shared.create(Todos(
+            category: "전체",
+            title: "test",
+            content: "내용"
+        ))
+        NavigationManager.shared.dismiss(animated: true)
+    }
+}
+
+extension RegisterViewController: UITextFieldDelegate {
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+        if let text = textField.text, text.isEmpty == true {
+            rightBarButton.isEnabled = false
+        }
+         else {
+            rightBarButton.isEnabled = true
+        }
+    }
+    
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        if let text = textField.text, text.isEmpty == true {
+            rightBarButton.isEnabled = false
+        }
+         else {
+            rightBarButton.isEnabled = true
+        }
+        
     }
 }
 

--- a/ReminderProject/ReminderProject/Views/RegisterView/RegisterViewController.swift
+++ b/ReminderProject/ReminderProject/Views/RegisterView/RegisterViewController.swift
@@ -42,7 +42,22 @@ final class RegisterViewController: BaseViewController<RegisterView> {
     override func configureDelegate() {
         super.configureDelegate()
         
+        baseView.memoView.textField.addTarget(
+            self,
+            action: #selector(textFieldTextChanged),
+            for: .editingChanged
+        )
         
+        baseView.memoView.textView.delegate = self
+    }
+    
+    @objc
+    func textFieldTextChanged(_ sender: UITextField) {
+        if let text = sender.text, !text.isEmpty {
+            rightBarButton.isEnabled = true
+        } else {
+            rightBarButton.isEnabled = false
+        }
     }
     
     @objc
@@ -53,32 +68,18 @@ final class RegisterViewController: BaseViewController<RegisterView> {
     // MARK: Fetch TextField from baseView
     @objc
     func addButtonTapped() {
+        guard let  title = baseView.memoView.textField.text else {
+            return
+        }
+        
+        let content = baseView.memoView.textView.text
+        
         RealmManager.shared.create(Todos(
-            category: "전체",
-            title: "test",
-            content: "내용"
+            category: "식품",
+            title: title,
+            content: content
         ))
         NavigationManager.shared.dismiss(animated: true)
-    }
-}
-
-extension RegisterViewController: UITextFieldDelegate {
-    func textFieldDidBeginEditing(_ textField: UITextField) {
-        if let text = textField.text, text.isEmpty == true {
-            rightBarButton.isEnabled = false
-        }
-         else {
-            rightBarButton.isEnabled = true
-        }
-    }
-    
-    func textFieldDidEndEditing(_ textField: UITextField) {
-        if let text = textField.text, text.isEmpty == true {
-            rightBarButton.isEnabled = false
-        }
-         else {
-            rightBarButton.isEnabled = true
-        }
     }
 }
 


### PR DESCRIPTION
## 🌱 *Pull requests*

🌿 **작업한 브랜치**
https://github.com/alpaka99/Reminder-Project/tree/%237/Feat/Implement-RealmDB

<br></br>

## 🔍 **작업한 결과**
- [x] Realm을 이용해서 Local DB를 구축합니다
- [x] 등록 화면에서 Create를 진행해봅니다
- [ ] 목록 화면에서 Read, Delete를 진행해봅니다

<br></br>
## 🔫 **Trouble Shooting**
- Realm 또한 기능을 분리해주기 위해 싱글톤 패턴을 사용하고자 RealmManager를 구현하였습니다. CRUD 관련 메서드들은 또 다른 model에도 대응할 수 있도록 Generic을 이용해서 작성했습니다
- Create, Read, Delete가 정상적으로 작동하는것을 확인했습니다. 다만 ViewController에서 호출하는 부분에서 baseView의 textField 값이라던가 데이터를 읽어오는 부분에 대한 처리가 고민입니다. 직접 참조를 최대한 줄이는 방법을 더 생각해봐야겠습니다.
-> #11 에서 해당 문제를 해결하여 PR을 남겨두었습니다. 요약하자면, 이제는 ViewController에서 View의 타입을 유추가 가능하여 직접 접근이 가능해졌습니다.

<br></br>
## 🔊 기타 공유사항
- 카테고리로 묶어서 sorting 할 수 있는 더 좋은 방법이 있는지 생각해보아야합니다.

<br></br>
## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|RealmManager를 이용한 Create and Read| ![Simulator Screen Recording - iPhone 15 Pro - 2024-07-03 at 23 34 11](https://github.com/alpaka99/Reminder-Project/assets/22471820/5757cdad-fd6d-4dc9-9cce-987a1f915038)|
|RealmManager를 이용한 Delete| ![Simulator Screen Recording - iPhone 15 Pro - 2024-07-03 at 23 35 25](https://github.com/alpaka99/Reminder-Project/assets/22471820/9704d093-5614-47d8-a9a8-2d8af8451dcd)|
| ActionSheet를 이용한 sort| ![Simulator Screen Recording - iPhone 15 Pro - 2024-07-03 at 23 35 00](https://github.com/alpaka99/Reminder-Project/assets/22471820/88d55dde-7d99-40a9-a511-cfd59ff18f55)|



## 📟 관련 이슈
- Resolved: #7 