### PR TITLE
Refactor: Refactor BaseViewController

### DIFF
--- a/ReminderProject/ReminderProject.xcodeproj/project.pbxproj
+++ b/ReminderProject/ReminderProject.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		CED1E0BB2C34538B004BFBE1 /* ListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E0BA2C34538B004BFBE1 /* ListView.swift */; };
 		CED1E0BD2C34596B004BFBE1 /* ListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E0BC2C34596B004BFBE1 /* ListTableViewCell.swift */; };
 		CED1E0C02C346ABC004BFBE1 /* NavigationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E0BF2C346ABC004BFBE1 /* NavigationManager.swift */; };
+		CED1E0CD2C356203004BFBE1 /* NSObject+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E0CC2C356203004BFBE1 /* NSObject+Extension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -62,6 +63,7 @@
 		CED1E0BA2C34538B004BFBE1 /* ListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListView.swift; sourceTree = "<group>"; };
 		CED1E0BC2C34596B004BFBE1 /* ListTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListTableViewCell.swift; sourceTree = "<group>"; };
 		CED1E0BF2C346ABC004BFBE1 /* NavigationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationManager.swift; sourceTree = "<group>"; };
+		CED1E0CC2C356203004BFBE1 /* NSObject+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSObject+Extension.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -164,6 +166,7 @@
 			isa = PBXGroup;
 			children = (
 				CED1E0A62C3409D5004BFBE1 /* UICollectionViewCell+Extension.swift */,
+				CED1E0CC2C356203004BFBE1 /* NSObject+Extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -291,6 +294,7 @@
 				CED1E09F2C34059D004BFBE1 /* MainCollectionViewCell.swift in Sources */,
 				CED1E0B02C341CDC004BFBE1 /* RegisterDisclosureCell.swift in Sources */,
 				CED1E0A92C340DEE004BFBE1 /* TodoCategory.swift in Sources */,
+				CED1E0CD2C356203004BFBE1 /* NSObject+Extension.swift in Sources */,
 				CED1E09D2C33FEF9004BFBE1 /* Constants.swift in Sources */,
 				CED1E0732C33E79C004BFBE1 /* AppDelegate.swift in Sources */,
 				CED1E0B92C345386004BFBE1 /* ListViewController.swift in Sources */,

--- a/ReminderProject/ReminderProject/Bases/BaseView.swift
+++ b/ReminderProject/ReminderProject/Bases/BaseView.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 class BaseView: UIView {
+    
     weak var delegate: BaseViewDelegate?
     
     override init(frame: CGRect) {
@@ -36,12 +37,10 @@ class BaseView: UIView {
         self.backgroundColor = .black
     }
     
-    internal func configureDelegate(_ vc: BaseViewController? = nil) {
-        self.delegate = vc
+    internal func configureDelegate() {
+        
     }
 }
 
 
-protocol BaseViewDelegate: BaseViewController {
-    func configureDelegate()
-}
+protocol BaseViewDelegate: AnyObject { }

--- a/ReminderProject/ReminderProject/Bases/BaseViewController.swift
+++ b/ReminderProject/ReminderProject/Bases/BaseViewController.swift
@@ -7,14 +7,15 @@
 
 import UIKit
 
-class BaseViewController: UIViewController {
-    private var baseView: BaseView? // force unwrapping 바꾸는 방법 생각해보기
+class BaseViewController<T: BaseView>: UIViewController {
+    internal let baseView: T
     
     override func loadView() {
         self.view = baseView
     }
     
-    required override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+    init(baseView: T) {
+        self.baseView = baseView
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -22,12 +23,6 @@ class BaseViewController: UIViewController {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
-    convenience init(baseView: BaseView) {
-        self.init(nibName: nil, bundle: nil)
-        self.baseView = baseView
-    }
-    
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -51,10 +46,8 @@ class BaseViewController: UIViewController {
     }
     
     internal func configureDelegate() {
-        baseView?.configureDelegate(self)
+        baseView.delegate = self
     }
 }
 
-extension BaseViewController: BaseViewDelegate {
-    
-}
+extension BaseViewController: BaseViewDelegate { }

--- a/ReminderProject/ReminderProject/Extensions/NSObject+Extension.swift
+++ b/ReminderProject/ReminderProject/Extensions/NSObject+Extension.swift
@@ -1,0 +1,14 @@
+//
+//  NSObject+Extension.swift
+//  ReminderProject
+//
+//  Created by user on 7/3/24.
+//
+
+import UIKit
+
+extension NSObject {
+    var objectName: String {
+        return String(describing: self)
+    }
+}

--- a/ReminderProject/ReminderProject/Managers/NavigationManager.swift
+++ b/ReminderProject/ReminderProject/Managers/NavigationManager.swift
@@ -29,7 +29,8 @@ final class NavigationManager {
         navigationController.dismiss(animated: true)
     }
     
-//    internal func replaceVC(_ vc: BaseViewController) {
+    // MARK: Replace VC -> self.navigationController를 새로 초기화해주고, window를 scenedelegate에서 끌고와서 다시 넣어주는 방식?
+//    internal func replaceVC(_ vc: BaseViewController<BaseView>) {
 //        let navigationController = UINavigationController(rootViewController: vc)
 //        
 //        self.window?.rootViewController = navigationController

--- a/ReminderProject/ReminderProject/Views/ListView/ListView.swift
+++ b/ReminderProject/ReminderProject/Views/ListView/ListView.swift
@@ -45,15 +45,4 @@ final class ListView: BaseView {
         
         tableView.backgroundColor = .clear
     }
-    
-    override func configureDelegate(_ vc: BaseViewController? = nil) {
-        super.configureDelegate()
-        
-        
-        tableView.delegate = vc as? any UITableViewDelegate
-        tableView.dataSource = vc as? any UITableViewDataSource
-
-        tableView.register(UITableViewCell.self, forCellReuseIdentifier: UITableViewCell.identifier)
-        tableView.register(ListTableViewCell.self, forCellReuseIdentifier: ListTableViewCell.identifier)
-    }
 }

--- a/ReminderProject/ReminderProject/Views/ListView/ListViewController.swift
+++ b/ReminderProject/ReminderProject/Views/ListView/ListViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class ListViewController: BaseViewController {
+final class ListViewController: BaseViewController<ListView> {
     private lazy var rightBarbutton = UIBarButtonItem(
         image: UIImage(systemName: "ellipsis.circle"),
         style: .plain,
@@ -19,6 +19,16 @@ final class ListViewController: BaseViewController {
         super.configureUI()
         
         navigationItem.rightBarButtonItem = rightBarbutton
+    }
+    
+    override func configureDelegate() {
+        super.configureDelegate()
+        
+        baseView.delegate = self
+        
+        baseView.tableView.delegate = self
+        baseView.tableView.dataSource = self
+        baseView.tableView.register(ListTableViewCell.self, forCellReuseIdentifier: ListTableViewCell.identifier)
     }
     
     @objc

--- a/ReminderProject/ReminderProject/Views/MainView/MainView.swift
+++ b/ReminderProject/ReminderProject/Views/MainView/MainView.swift
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 
 final class MainView: BaseView {
-    private let titleLabel = {
+    private(set) var titleLabel = {
         let label = UILabel()
         label.text = "전체"
         label.font = .systemFont(ofSize: 32, weight: .semibold)
@@ -18,7 +18,7 @@ final class MainView: BaseView {
         return label
     }()
     
-    private let collectionView = {
+    private(set) var collectionView = {
         let collectionView = UICollectionView(
             frame: .zero,
             collectionViewLayout: UICollectionView.flowLayout(
@@ -31,7 +31,7 @@ final class MainView: BaseView {
         return collectionView
     }()
     
-    private let newTodoButton = {
+    private(set) var newTodoButton = {
         let button = UIButton()
         var config = UIButton.Configuration.plain()
         config.image = UIImage(systemName: "plus.circle.fill")
@@ -43,7 +43,7 @@ final class MainView: BaseView {
         return button
     }()
     
-    private let addListButton = {
+    private(set) var addListButton = {
         let button = UIButton()
         var config = UIButton.Configuration.plain()
         config.title = "목록 추가"
@@ -104,16 +104,6 @@ final class MainView: BaseView {
             action: #selector(addListButtonTapped),
             for: .touchUpInside
         )
-    }
-    
-    override func configureDelegate(_ vc: BaseViewController?) {
-        super.configureDelegate()
-        
-        collectionView.delegate = vc as? any UICollectionViewDelegate
-        collectionView.dataSource = vc as? any UICollectionViewDataSource
-        
-        collectionView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: UICollectionViewCell.identifier)
-        collectionView.register(MainCollectionViewCell.self, forCellWithReuseIdentifier: MainCollectionViewCell.identifier)
     }
     
     @objc

--- a/ReminderProject/ReminderProject/Views/MainView/MainViewController.swift
+++ b/ReminderProject/ReminderProject/Views/MainView/MainViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class MainViewController: BaseViewController {
+final class MainViewController: BaseViewController<MainView> {
     private let categories: [TodoCategory] = TodoCategory.allCases
     private lazy var rightBarbutton = UIBarButtonItem(image: UIImage(systemName: "ellipsis.circle"), style: .plain, target: self, action: #selector(rightBarButtonTapped))
     
@@ -19,6 +19,14 @@ final class MainViewController: BaseViewController {
     
     @objc func rightBarButtonTapped() {
         print(#function)
+    }
+    
+    override func configureDelegate() {
+        super.configureDelegate()
+        
+        baseView.collectionView.delegate = self
+        baseView.collectionView.dataSource = self
+        baseView.collectionView.register(MainCollectionViewCell.self, forCellWithReuseIdentifier: MainCollectionViewCell.identifier)
     }
 }
 
@@ -36,3 +44,5 @@ extension MainViewController: UICollectionViewDelegate, UICollectionViewDataSour
         return cell
     }
 }
+
+

--- a/ReminderProject/ReminderProject/Views/RegisterView/RegisterOpenedCell.swift
+++ b/ReminderProject/ReminderProject/Views/RegisterView/RegisterOpenedCell.swift
@@ -67,10 +67,4 @@ final class RegisterOpenedCell: BaseView {
         textView.font = .systemFont(ofSize: 18)
         textView.textContainer.maximumNumberOfLines = 8
     }
-    
-    override func configureDelegate(_ vc: BaseViewController? = nil) {
-        super.configureDelegate()
-        
-        textView.delegate = vc as? any UITextViewDelegate
-    }
 }

--- a/ReminderProject/ReminderProject/Views/RegisterView/RegisterView.swift
+++ b/ReminderProject/ReminderProject/Views/RegisterView/RegisterView.swift
@@ -9,9 +9,9 @@ import UIKit
 
 import SnapKit
 
-final class RegisterView: BaseView {
-    private let memoView = RegisterOpenedCell()
-    private lazy var stackView = UIStackView()
+final class RegisterView: BaseView{
+    let memoView = RegisterOpenedCell()
+    lazy var stackView = UIStackView()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -56,12 +56,9 @@ final class RegisterView: BaseView {
         }
     }
     
-    override func configureDelegate(_ vc: BaseViewController? = nil) {
-        super.configureDelegate()
-        
-        self.delegate = vc
-        
-        memoView.configureDelegate(vc)
+    
+    deinit {
+        print(#function, objectName)
     }
 }
 

--- a/ReminderProject/ReminderProject/Views/RegisterView/RegisterViewController.swift
+++ b/ReminderProject/ReminderProject/Views/RegisterView/RegisterViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class RegisterViewController: BaseViewController {
+final class RegisterViewController: BaseViewController<RegisterView> {
     private let registerFieldTypes: [RegisterFieldType] = RegisterFieldType.allCases
     
     private lazy var leftBarButton = {
@@ -39,6 +39,12 @@ final class RegisterViewController: BaseViewController {
         navigationItem.rightBarButtonItem = rightBarButton
     }
     
+    override func configureDelegate() {
+        super.configureDelegate()
+        
+        
+    }
+    
     @objc
     func cancelButtonTapped() {
         NavigationManager.shared.dismiss(animated: true)
@@ -46,7 +52,7 @@ final class RegisterViewController: BaseViewController {
     
     @objc
     func addButtonTapped() {
-        print(#function)
+//        print(#function)
     }
 }
 


### PR DESCRIPTION
## 🌱 *Pull requests*

🌿 **작업한 브랜치**
https://github.com/alpaka99/Reminder-Project/tree/%2311/Refactor/Refactor-Project-Pattern

<br></br>

## 🔍 **작업한 결과**
- BaseViewController에서 Generic을 이용한 변경 사항이 생겼습니다. 이제 더 이상 ViewController의 baseView가 단순히 BaseView Type이 아닌, 구체 타입으로 특정할 수 있어 baseView의 프로퍼티와 메서드를 호출해서 사용할 수 있게 되었습니다.

<br></br>
## 🔫 **Trouble Shooting**
### 변경 전
- 기존의 코드에서는 BaseViewController의 init 과정에서 단순히 BaseView 타입을 받아, baseView 프로퍼티에 저장하고 있었습니다. 따라서 BaseView를 서브클래싱하는 타입이어도, BaseView Type으로 저장되었기에, 서브클래스 특유의 프로퍼티 혹은 메서드에 접근하지 못하였습니다.
- 이에 따라 viewController가 스스로를 baseView에 전달해서 delegate 설정등을 하는 reference cycle이 생길 수 있는 방법을 사용하고 있었습니다. Instrument로 확인 결과 leak은 확인하지 못했지만, 구조가 복잡해질수록 그럴 가능성이 높다고 판단하였습니다.
- 또한 baseView의 뷰 프로퍼티에 직접 접근하지 못하다보니, addTarget등을 viewController에서 처리하지 못하고 view에서 처리해야하는, 그렇게 떼어놓고 싶던 기능에 관한 부분이 다시 view에 들어가는 모순점이 생겼습니다.
```swift
// Before Refactoring
class BaseViewController: UIViewController {
    init(baseView: BaseView) {
    // some codes
    }
}
```

### 변경 후
- BaseViewController의 init 과정에서 generic을 이용해 baseView의 type을 제한만 해줍니다(type constraint). 이렇게 한 후에 실제 BaseViewController를 상속받은 ViewController들을 초기화할때, 어떤 baseView의 서브 클래스가 들어올지 명시해줍니다.
```swift
class BaseViewController<T: BaseView> { // Generic as type constraint
    init(baseView: T) {
        // some codes
    }
}


final class ChildViewController: BaseViewController<ChildView> {  // 여기서 compiler가 baseView의 type을 유추할 수 있게 됨
    // some codes...
    baseView.ChildViewProperty = "Acessing Some BaseView Subclass Property"
}
```

<br></br>
## 🔊 기타 공유사항
- BaseViewController의 수정은 있었지만, 아직 완벽하게 깔끔한 구조는 아니라고 생각해서 추후에 수정을 더 할 수 있겠습니다.


<br></br>
<!-- 이미지 자료가 있다면 적어주세요
## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
||<img src = "">
||<img src = "">
<br></br>
-->

## 📟 관련 이슈
- Resolved: #11 
