### PR TITLE
#13/feat/implement detail memo

### DIFF
--- a/ReminderProject/ReminderProject.xcodeproj/project.pbxproj
+++ b/ReminderProject/ReminderProject.xcodeproj/project.pbxproj
@@ -38,6 +38,10 @@
 		CED1E0C82C3497E2004BFBE1 /* ViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E0C72C3497E2004BFBE1 /* ViewController+Extension.swift */; };
 		CED1E0CD2C356203004BFBE1 /* NSObject+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E0CC2C356203004BFBE1 /* NSObject+Extension.swift */; };
 		CED1E0CF2C359FFC004BFBE1 /* Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E0CE2C359FFC004BFBE1 /* Category.swift */; };
+		CED1E0D12C35ADA4004BFBE1 /* RegisterFieldType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E0D02C35ADA4004BFBE1 /* RegisterFieldType.swift */; };
+		CED1E0D32C35B125004BFBE1 /* DetailInputViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E0D22C35B125004BFBE1 /* DetailInputViewController.swift */; };
+		CED1E0D62C35B151004BFBE1 /* DetailInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E0D52C35B151004BFBE1 /* DetailInputView.swift */; };
+		CED1E0D82C35C851004BFBE1 /* DateHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E0D72C35C851004BFBE1 /* DateHelper.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -72,6 +76,10 @@
 		CED1E0C72C3497E2004BFBE1 /* ViewController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Extension.swift"; sourceTree = "<group>"; };
 		CED1E0CC2C356203004BFBE1 /* NSObject+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSObject+Extension.swift"; sourceTree = "<group>"; };
 		CED1E0CE2C359FFC004BFBE1 /* Category.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Category.swift; sourceTree = "<group>"; };
+		CED1E0D02C35ADA4004BFBE1 /* RegisterFieldType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterFieldType.swift; sourceTree = "<group>"; };
+		CED1E0D22C35B125004BFBE1 /* DetailInputViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailInputViewController.swift; sourceTree = "<group>"; };
+		CED1E0D52C35B151004BFBE1 /* DetailInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailInputView.swift; sourceTree = "<group>"; };
+		CED1E0D72C35C851004BFBE1 /* DateHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateHelper.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -137,6 +145,7 @@
 		CED1E0952C33FA88004BFBE1 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				CED1E0D42C35B13E004BFBE1 /* DetailInputViewController */,
 				CED1E0B72C345368004BFBE1 /* ListView */,
 				CED1E0AA2C34153F004BFBE1 /* RegisterView */,
 				CED1E0962C33FA91004BFBE1 /* MainView */,
@@ -159,6 +168,8 @@
 			children = (
 				CED1E09C2C33FEF9004BFBE1 /* Constants.swift */,
 				CED1E0A82C340DEE004BFBE1 /* TodoCategory.swift */,
+				CED1E0D02C35ADA4004BFBE1 /* RegisterFieldType.swift */,
+				CED1E0D72C35C851004BFBE1 /* DateHelper.swift */,
 			);
 			path = Constants;
 			sourceTree = "<group>";
@@ -226,6 +237,15 @@
 				CED1E0CE2C359FFC004BFBE1 /* Category.swift */,
 			);
 			path = RealmModels;
+			sourceTree = "<group>";
+		};
+		CED1E0D42C35B13E004BFBE1 /* DetailInputViewController */ = {
+			isa = PBXGroup;
+			children = (
+				CED1E0D22C35B125004BFBE1 /* DetailInputViewController.swift */,
+				CED1E0D52C35B151004BFBE1 /* DetailInputView.swift */,
+			);
+			path = DetailInputViewController;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -310,6 +330,7 @@
 				CED1E0B42C341ED3004BFBE1 /* BaseTableViewCell.swift in Sources */,
 				CED1E0BB2C34538B004BFBE1 /* ListView.swift in Sources */,
 				CED1E0C02C346ABC004BFBE1 /* NavigationManager.swift in Sources */,
+				CED1E0D12C35ADA4004BFBE1 /* RegisterFieldType.swift in Sources */,
 				CED1E0982C33FA98004BFBE1 /* MainViewController.swift in Sources */,
 				CED1E09A2C33FAA9004BFBE1 /* MainView.swift in Sources */,
 				CED1E0A12C3405A9004BFBE1 /* BaseCollectionViewCell.swift in Sources */,
@@ -321,6 +342,7 @@
 				CED1E0B62C342DD1004BFBE1 /* RegisterOpenedCell.swift in Sources */,
 				CED1E0BD2C34596B004BFBE1 /* ListTableViewCell.swift in Sources */,
 				CED1E0C62C348920004BFBE1 /* Todos.swift in Sources */,
+				CED1E0D82C35C851004BFBE1 /* DateHelper.swift in Sources */,
 				CED1E0922C33F056004BFBE1 /* BaseView.swift in Sources */,
 				CED1E09F2C34059D004BFBE1 /* MainCollectionViewCell.swift in Sources */,
 				CED1E0C22C34870D004BFBE1 /* RealmManager.swift in Sources */,
@@ -330,7 +352,9 @@
 				CED1E09D2C33FEF9004BFBE1 /* Constants.swift in Sources */,
 				CED1E0732C33E79C004BFBE1 /* AppDelegate.swift in Sources */,
 				CED1E0B92C345386004BFBE1 /* ListViewController.swift in Sources */,
+				CED1E0D32C35B125004BFBE1 /* DetailInputViewController.swift in Sources */,
 				CED1E0AC2C341555004BFBE1 /* RegisterViewController.swift in Sources */,
+				CED1E0D62C35B151004BFBE1 /* DetailInputView.swift in Sources */,
 				CED1E0752C33E79C004BFBE1 /* SceneDelegate.swift in Sources */,
 				CED1E0A72C3409D5004BFBE1 /* UICollectionViewCell+Extension.swift in Sources */,
 			);

--- a/ReminderProject/ReminderProject.xcodeproj/project.pbxproj
+++ b/ReminderProject/ReminderProject.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		CED1E0C62C348920004BFBE1 /* Todos.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E0C52C348920004BFBE1 /* Todos.swift */; };
 		CED1E0C82C3497E2004BFBE1 /* ViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E0C72C3497E2004BFBE1 /* ViewController+Extension.swift */; };
 		CED1E0CD2C356203004BFBE1 /* NSObject+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E0CC2C356203004BFBE1 /* NSObject+Extension.swift */; };
+		CED1E0CF2C359FFC004BFBE1 /* Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E0CE2C359FFC004BFBE1 /* Category.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -70,6 +71,7 @@
 		CED1E0C52C348920004BFBE1 /* Todos.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Todos.swift; sourceTree = "<group>"; };
 		CED1E0C72C3497E2004BFBE1 /* ViewController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Extension.swift"; sourceTree = "<group>"; };
 		CED1E0CC2C356203004BFBE1 /* NSObject+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSObject+Extension.swift"; sourceTree = "<group>"; };
+		CED1E0CE2C359FFC004BFBE1 /* Category.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Category.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -221,6 +223,7 @@
 			isa = PBXGroup;
 			children = (
 				CED1E0C52C348920004BFBE1 /* Todos.swift */,
+				CED1E0CE2C359FFC004BFBE1 /* Category.swift */,
 			);
 			path = RealmModels;
 			sourceTree = "<group>";
@@ -313,6 +316,7 @@
 				CED1E0AE2C34156B004BFBE1 /* RegisterView.swift in Sources */,
 				CED1E0902C33EFE5004BFBE1 /* BaseViewController.swift in Sources */,
 				CED1E0C82C3497E2004BFBE1 /* ViewController+Extension.swift in Sources */,
+				CED1E0CF2C359FFC004BFBE1 /* Category.swift in Sources */,
 				CED1E0A42C3408D0004BFBE1 /* Reusable.swift in Sources */,
 				CED1E0B62C342DD1004BFBE1 /* RegisterOpenedCell.swift in Sources */,
 				CED1E0BD2C34596B004BFBE1 /* ListTableViewCell.swift in Sources */,

--- a/ReminderProject/ReminderProject/AppDelegate.swift
+++ b/ReminderProject/ReminderProject/AppDelegate.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import RealmSwift
+
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
@@ -14,6 +16,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
+        
+        // Realm Schema Migration
+        let config = Realm.Configuration(schemaVersion: 1) { migration,oldSchemaVersion in
+            if oldSchemaVersion < 1 {
+                // TodoTable에 dueDate column 추가
+            }
+        }
+        
+        Realm.Configuration.defaultConfiguration = config
+        
+        
         return true
     }
 

--- a/ReminderProject/ReminderProject/AppDelegate.swift
+++ b/ReminderProject/ReminderProject/AppDelegate.swift
@@ -18,7 +18,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Override point for customization after application launch.
         
         // Realm Schema Migration
-        let config = Realm.Configuration(schemaVersion: 1) { migration,oldSchemaVersion in
+        let config = Realm.Configuration(schemaVersion: 2) { migration,oldSchemaVersion in
             if oldSchemaVersion < 1 {
                 // TodoTable에 dueDate column 추가
             }

--- a/ReminderProject/ReminderProject/Constants/DateHelper.swift
+++ b/ReminderProject/ReminderProject/Constants/DateHelper.swift
@@ -1,0 +1,28 @@
+//
+//  DateHelper.swift
+//  ReminderProject
+//
+//  Created by user on 7/4/24.
+//
+
+import Foundation
+
+class DateHelper {
+    private let dateFormatter = DateFormatter()
+    private let dateFormat = "yyyy.MM.dd"
+    static let shared = DateHelper()
+    
+    
+    init() {
+        dateFormatter.dateFormat = dateFormat
+    }
+    
+    func date(from text: String) -> Date? {
+        return dateFormatter.date(from: text)
+    }
+    
+    func string(from date: Date?) -> String? {
+        guard let date = date else { return nil }
+        return dateFormatter.string(from: date)
+    }
+}

--- a/ReminderProject/ReminderProject/Constants/RegisterFieldType.swift
+++ b/ReminderProject/ReminderProject/Constants/RegisterFieldType.swift
@@ -1,0 +1,30 @@
+//
+//  RegisterFieldType.swift
+//  ReminderProject
+//
+//  Created by user on 7/4/24.
+//
+
+enum RegisterFieldType: CaseIterable {
+//    case memo(RegisterFieldMode)
+    case dueDate
+    case tag
+    case priority
+    case image
+    
+    var title: String {
+        switch self {
+//        case .memo(_):
+//            return "제목"
+        case .dueDate:
+            return "마감일"
+        case .tag:
+            return "태그"
+        case .priority:
+            return "우선순위"
+        case .image:
+            return "이미지 추가"
+        }
+    }
+    
+}

--- a/ReminderProject/ReminderProject/Models/RealmModels/Category.swift
+++ b/ReminderProject/ReminderProject/Models/RealmModels/Category.swift
@@ -1,0 +1,16 @@
+//
+//  Category.swift
+//  ReminderProject
+//
+//  Created by user on 7/4/24.
+//
+
+import RealmSwift
+
+// TODO: Add RelationShip to Todo Table
+final class Category: Object {
+    @Persisted(primaryKey: true) var _id: ObjectId
+    @Persisted var categoryName: String
+    @Persisted var iconName: String
+    @Persisted var backgroundColor: String
+}

--- a/ReminderProject/ReminderProject/Models/RealmModels/Todos.swift
+++ b/ReminderProject/ReminderProject/Models/RealmModels/Todos.swift
@@ -9,24 +9,27 @@ import Foundation
 
 import RealmSwift
 
-class Todos: Object {
+final class Todos: Object {
     @Persisted(primaryKey: true) var _id: ObjectId
     @Persisted(indexed: true) var category: String
     @Persisted var title: String
     @Persisted var content: String?
+    @Persisted var dueDate: Date?
     @Persisted var createdAt: Date
     
     convenience init(
-        category: String,
         title: String,
+        category: String,
         content: String? = nil,
+        dueDate: Date? = nil,
         createdAt: Date = Date.now
     ) {
         self.init()
         
-        self.category = category
         self.title = title
+        self.category = category
         self.content = content
+        self.dueDate = dueDate
         self.createdAt = createdAt
     }
 }

--- a/ReminderProject/ReminderProject/Models/RealmModels/Todos.swift
+++ b/ReminderProject/ReminderProject/Models/RealmModels/Todos.swift
@@ -11,25 +11,34 @@ import RealmSwift
 
 final class Todos: Object {
     @Persisted(primaryKey: true) var _id: ObjectId
-    @Persisted(indexed: true) var category: String
-    @Persisted var title: String
-    @Persisted var content: String?
-    @Persisted var dueDate: Date?
     @Persisted var createdAt: Date
     
+    @Persisted var title: String
+    @Persisted var content: String?
+    @Persisted(indexed: true) var category: String
+    @Persisted var dueDate: Date?
+    @Persisted var priority: Int?
+    @Persisted var tag: String?
+    
+    
     convenience init(
+        createdAt: Date = Date.now,
         title: String,
-        category: String,
         content: String? = nil,
+        category: String,
         dueDate: Date? = nil,
-        createdAt: Date = Date.now
+        tag: String? = nil,
+        priority: Int? = nil
     ) {
         self.init()
         
-        self.title = title
-        self.category = category
-        self.content = content
-        self.dueDate = dueDate
         self.createdAt = createdAt
+        
+        self.title = title
+        self.content = content
+        self.category = category
+        self.dueDate = dueDate
+        self.tag = tag
+        self.priority = priority
     }
 }

--- a/ReminderProject/ReminderProject/Views/DetailInputViewController/DetailInputView.swift
+++ b/ReminderProject/ReminderProject/Views/DetailInputViewController/DetailInputView.swift
@@ -1,0 +1,130 @@
+//
+//  DetailInputView.swift
+//  ReminderProject
+//
+//  Created by user on 7/4/24.
+//
+
+import UIKit
+
+import SnapKit
+
+final class DetailInputView: BaseView {
+    var type: RegisterFieldType?
+    
+    let datePicker = {
+        let datePicker = UIDatePicker(frame: .zero)
+        datePicker.datePickerMode = .date
+        
+        
+        datePicker.backgroundColor = .white
+        datePicker.alpha = 0
+        
+        return datePicker
+    }()
+    
+    let textField = {
+        let textField = UITextField()
+        
+        textField.backgroundColor = .darkGray
+        textField.layer.cornerRadius = 8
+        textField.alpha = 0
+        
+        return textField
+    }()
+    
+    let segmentedControl = {
+        let segmentedControl = UISegmentedControl(items: ["High🔴", "Middle🟡", "Low🟣"])
+        
+        segmentedControl.backgroundColor = .darkGray
+        segmentedControl.selectedSegmentIndex = 0
+        segmentedControl.alpha = 0
+        
+        return segmentedControl
+    }()
+    
+    let imagePicker = {
+        let label = UILabel()
+        
+        label.text = "Comming soon..."
+        label.alpha = 0
+        
+        return label
+    }()
+    
+    override func configureHierarchy() {
+        super.configureHierarchy()
+        
+        self.addSubview(datePicker)
+        self.addSubview(textField)
+        self.addSubview(segmentedControl)
+        self.addSubview(imagePicker)
+    }
+    
+    override func configureLayout() {
+        super.configureLayout()
+        
+        datePicker.snp.makeConstraints {
+            $0.center.equalTo(self)
+            $0.height.equalTo(50)
+            $0.width.equalTo(self.snp.width)
+                .multipliedBy(0.8)
+        }
+        
+        textField.snp.makeConstraints {
+            $0.center.equalTo(self)
+            $0.height.equalTo(50)
+            $0.width.equalTo(self.snp.width)
+                .multipliedBy(0.8)
+        }
+        
+        segmentedControl.snp.makeConstraints {
+            $0.center.equalTo(self)
+            $0.height.equalTo(50)
+            $0.width.equalTo(self.snp.width)
+                .multipliedBy(0.8)
+        }
+        
+        imagePicker.snp.makeConstraints {
+            $0.center.equalTo(self)
+            $0.height.equalTo(50)
+            $0.width.equalTo(self.snp.width)
+                .multipliedBy(0.8)
+        }
+    }
+    
+    
+    internal func configureData(_ type: RegisterFieldType) {
+        self.type = type
+        
+        switch type {
+        case .dueDate:
+            datePicker.alpha = 1
+        case .tag:
+            textField.alpha = 1
+        case .priority:
+            segmentedControl.alpha = 1
+        case .image:
+            imagePicker.alpha = 1
+        }
+    }
+    
+    internal func sendDetailData() -> String {
+        guard let type = type else { return "" }
+        switch type {
+        case .dueDate:
+            guard let date = DateHelper.shared.string(from: datePicker.date) else { return "" }
+            return date
+        case .tag:
+            if let text = textField.text {
+                return text
+            }
+        case .priority:
+            return String(segmentedControl.selectedSegmentIndex)
+        case .image:
+            return "Comming Soon"
+        }
+        
+        return ""
+    }
+}

--- a/ReminderProject/ReminderProject/Views/DetailInputViewController/DetailInputViewController.swift
+++ b/ReminderProject/ReminderProject/Views/DetailInputViewController/DetailInputViewController.swift
@@ -1,0 +1,46 @@
+//
+//  DetailInputViewController.swift
+//  ReminderProject
+//
+//  Created by user on 7/4/24.
+//
+
+import UIKit
+
+final class DetailInputViewController: BaseViewController<DetailInputView> {
+    private var type: RegisterFieldType? = .dueDate
+    
+    weak var delegate: DetailInputDelegate?
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        guard let type = type else { return }
+        let detailData = baseView.sendDetailData()
+        
+        delegate?.sendDetailData(type, text: detailData)
+    }
+    
+    override func configureUI() {
+        super.configureUI()
+        
+        guard let type = type else { return }
+        baseView.configureData(type)
+        
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "완료", style: .plain, target: self, action: #selector(completeButtonTapped))
+    }
+    
+    internal func configureData(_ type: RegisterFieldType) {
+        self.type = type
+    }
+    
+    @objc
+    func completeButtonTapped() {
+        navigationController?.popViewController(animated: true)
+    }
+}
+
+
+protocol DetailInputDelegate: AnyObject {
+    func sendDetailData(_ type: RegisterFieldType, text: String)
+}

--- a/ReminderProject/ReminderProject/Views/ListView/ListTableViewCell.swift
+++ b/ReminderProject/ReminderProject/Views/ListView/ListTableViewCell.swift
@@ -93,7 +93,7 @@ final class ListTableViewCell: BaseTableViewCell {
     func configureData(_ data: Todos) {
         title.text = data.title
         content.text = data.content
-        dateLabel.text = data.createdAt.formatted()
-        tagLabel.text = "#쇼핑"
+        dateLabel.text = DateHelper.shared.string(from: data.dueDate)
+        tagLabel.text = data.tag
     }
 }

--- a/ReminderProject/ReminderProject/Views/ListView/ListTableViewCell.swift
+++ b/ReminderProject/ReminderProject/Views/ListView/ListTableViewCell.swift
@@ -9,6 +9,7 @@ import UIKit
 
 final class ListTableViewCell: BaseTableViewCell {
     private let toggleButton = UIButton()
+    private let priority = UILabel()
     private let title = UILabel()
     private let content = UILabel()
     private let dateLabel = UILabel()
@@ -18,6 +19,7 @@ final class ListTableViewCell: BaseTableViewCell {
         super.configureHierarchy()
         
         contentView.addSubview(toggleButton)
+        contentView.addSubview(priority)
         contentView.addSubview(title)
         contentView.addSubview(content)
         contentView.addSubview(dateLabel)
@@ -37,11 +39,17 @@ final class ListTableViewCell: BaseTableViewCell {
                 .multipliedBy(1)
         }
         
-        title.snp.makeConstraints {
+        priority.snp.makeConstraints {
             $0.leading.equalTo(toggleButton.snp.trailing)
                 .offset(8)
-            $0.trailing.equalTo(contentView)
+            $0.centerY.equalTo(toggleButton.snp.centerY)
+        }
+        
+        title.snp.makeConstraints {
+            $0.leading.equalTo(priority.snp.trailing)
                 .offset(8)
+            $0.trailing.lessThanOrEqualTo(contentView)
+                .offset(-8)
             $0.centerY.equalTo(toggleButton.snp.centerY)
         }
         
@@ -73,6 +81,8 @@ final class ListTableViewCell: BaseTableViewCell {
         
         toggleButton.setImage(UIImage(systemName: "circle"), for: .normal)
         
+        priority.font = .systemFont(ofSize: 16, weight: .semibold)
+        priority.textColor = .white
         
         title.font = .systemFont(ofSize: 16, weight: .semibold)
         title.textColor = .white
@@ -94,6 +104,7 @@ final class ListTableViewCell: BaseTableViewCell {
         title.text = data.title
         content.text = data.content
         dateLabel.text = DateHelper.shared.string(from: data.dueDate)
+        priority.text = String(data.priority ?? -1)
         tagLabel.text = data.tag
     }
 }

--- a/ReminderProject/ReminderProject/Views/ListView/ListView.swift
+++ b/ReminderProject/ReminderProject/Views/ListView/ListView.swift
@@ -10,8 +10,21 @@ import UIKit
 import SnapKit
 
 final class ListView: BaseView {
-    let titleLabel = UILabel()
-    let tableView = UITableView()
+    let titleLabel = {
+        let label = UILabel()
+        label.text = "전체"
+        label.textColor = .systemBlue
+        label.font = .systemFont(ofSize: 40, weight: .bold)
+        return label
+    }()
+    
+    let tableView = {
+        let tableView = UITableView()
+        
+        tableView.backgroundColor = .clear
+        
+        return tableView
+    }()
     
     override func configureHierarchy() {
         super.configureHierarchy()
@@ -33,16 +46,5 @@ final class ListView: BaseView {
                 .offset(16)
             $0.horizontalEdges.bottom.equalTo(self.safeAreaLayoutGuide)
         }
-    }
-    
-    
-    override func configureUI() {
-        super.configureUI()
-        
-        titleLabel.text = "전체"
-        titleLabel.textColor = .systemBlue
-        titleLabel.font = .systemFont(ofSize: 40, weight: .bold)
-        
-        tableView.backgroundColor = .clear
     }
 }

--- a/ReminderProject/ReminderProject/Views/ListView/ListViewController.swift
+++ b/ReminderProject/ReminderProject/Views/ListView/ListViewController.swift
@@ -41,11 +41,11 @@ final class ListViewController: BaseViewController<ListView> {
             preferredStyle: .actionSheet
         )
         let dueDateSort = UIAlertAction(
-            title: "날짜 순",
+            title: "카테고리 순",
             style: .default
         ) {[weak self] _ in
             self?.results = self?.results?.sorted(
-                byKeyPath: "createdAt",
+                byKeyPath: "category",
                 ascending: true
             )
             self?.baseView.tableView.reloadData()
@@ -61,11 +61,11 @@ final class ListViewController: BaseViewController<ListView> {
             self?.baseView.tableView.reloadData()
         }
         let memoSort = UIAlertAction(
-            title: "메모 순",
+            title: "마감일 순",
             style: .default
         ) { [weak self] _ in
             self?.results = self?.results?.sorted(
-                byKeyPath: "content",
+                byKeyPath: "dueDate",
                 ascending: true
             )
             self?.baseView.tableView.reloadData()

--- a/ReminderProject/ReminderProject/Views/RegisterView/RegisterDisclosureCell.swift
+++ b/ReminderProject/ReminderProject/Views/RegisterView/RegisterDisclosureCell.swift
@@ -10,13 +10,38 @@ import UIKit
 import SnapKit
 
 final class RegisterDisclosureCell: BaseView {
-    private let title = UILabel()
-    private let trailingButton = UIButton()
+    let title = {
+        let label = UILabel()
+        
+        label.textColor = .systemGray4
+        label.font = .systemFont(ofSize: 16, weight: .semibold)
+        
+        return label
+    }()
+    
+    let content = {
+        let label = UILabel()
+        
+        label.textColor = .systemGray4
+        label.font = .systemFont(ofSize: 16, weight: .semibold)
+        
+        return label
+    }()
+    
+    let trailingButton = {
+        let button = UIButton()
+        
+        button.setImage(UIImage(systemName: "chevron.right"), for: .normal)
+        button.tintColor = .systemGray4
+        
+        return button
+    }()
     
     override func configureHierarchy() {
         super.configureHierarchy()
         
         self.addSubview(title)
+        self.addSubview(content)
         self.addSubview(trailingButton)
     }
     
@@ -25,6 +50,13 @@ final class RegisterDisclosureCell: BaseView {
         
         title.snp.makeConstraints {
             $0.leading.equalTo(self.snp.leading)
+                .offset(16)
+            $0.verticalEdges.equalTo(self.snp.verticalEdges)
+                .inset(16)
+        }
+        
+        content.snp.makeConstraints {
+            $0.leading.equalTo(title.snp.trailing)
                 .offset(16)
             $0.verticalEdges.equalTo(self.snp.verticalEdges)
                 .inset(16)
@@ -47,15 +79,15 @@ final class RegisterDisclosureCell: BaseView {
         self.layer.cornerRadius = 8
         self.clipsToBounds = true
         
-        title.text = "타이틀"
         title.textColor = .systemGray4
         title.font = .systemFont(ofSize: 16, weight: .semibold)
-        
-        trailingButton.setImage(UIImage(systemName: "chevron.right"), for: .normal)
-        trailingButton.tintColor = .systemGray4
     }
     
-    func configureData(_ type: RegisterFieldType) {
-        title.text = type.title
+    func configureData(_ text: String) {
+        title.text = text
     }
+}
+
+protocol DisclosureCellDelegate {
+    func trailingButtonTapped()
 }

--- a/ReminderProject/ReminderProject/Views/RegisterView/RegisterView.swift
+++ b/ReminderProject/ReminderProject/Views/RegisterView/RegisterView.swift
@@ -11,6 +11,39 @@ import SnapKit
 
 final class RegisterView: BaseView {
     let memoView = RegisterOpenedCell()
+    
+    private(set) var dueDateTextField = {
+        let disclosureCell = RegisterDisclosureCell()
+        
+        disclosureCell.configureData("마감일")
+        
+        return disclosureCell
+    }()
+    
+    private(set) var tagTextField = {
+        let disclosureCell = RegisterDisclosureCell()
+        
+        disclosureCell.configureData("태그")
+        
+        return disclosureCell
+    }()
+    
+    private(set) var priorityTextField = {
+        let disclosureCell = RegisterDisclosureCell()
+        
+        disclosureCell.configureData("우선 순위")
+        
+        return disclosureCell
+    }()
+    
+    private(set) var imageTextField = {
+        let disclosureCell = RegisterDisclosureCell()
+        
+        disclosureCell.configureData("이미지 추가")
+        
+        return disclosureCell
+    }()
+    
     lazy var stackView = UIStackView()
     
     override init(frame: CGRect) {
@@ -48,48 +81,9 @@ final class RegisterView: BaseView {
     func configureArrandedSubViews() {
         stackView.addArrangedSubview(memoView)
         
-        RegisterFieldType.allCases.forEach { type in
-            let registerDisclosureView = RegisterDisclosureCell()
-            
-            registerDisclosureView.configureData(type)
-            stackView.addArrangedSubview(registerDisclosureView)
-        }
+        stackView.addArrangedSubview(dueDateTextField)
+        stackView.addArrangedSubview(tagTextField)
+        stackView.addArrangedSubview(priorityTextField)
+        stackView.addArrangedSubview(imageTextField)
     }
-}
-
-enum RegisterFieldType: CaseIterable {
-    static var allCases: [RegisterFieldType] = [
-//        memo(.opened),
-        dDay(.disclosured),
-        tag(.disclosured),
-        priority(.disclosured),
-        image(.disclosured)
-    ]
-    
-//    case memo(RegisterFieldMode)
-    case dDay(RegisterFieldMode)
-    case tag(RegisterFieldMode)
-    case priority(RegisterFieldMode)
-    case image(RegisterFieldMode)
-    
-    var title: String {
-        switch self {
-//        case .memo(_):
-//            return "제목"
-        case .dDay(_):
-            return "마감일"
-        case .tag(_):
-            return "태그"
-        case .priority(_):
-            return "우선순위"
-        case .image(_):
-            return "이미지 추가"
-        }
-    }
-    
-}
-
-enum RegisterFieldMode {
-    case opened
-    case disclosured
 }

--- a/ReminderProject/ReminderProject/Views/RegisterView/RegisterViewController.swift
+++ b/ReminderProject/ReminderProject/Views/RegisterView/RegisterViewController.swift
@@ -75,8 +75,8 @@ final class RegisterViewController: BaseViewController<RegisterView> {
         let content = baseView.memoView.textView.text
         
         RealmManager.shared.create(Todos(
-            category: "식품",
             title: title,
+            category: "식품",
             content: content
         ))
         NavigationManager.shared.dismiss(animated: true)

--- a/ReminderProject/ReminderProject/Views/RegisterView/RegisterViewController.swift
+++ b/ReminderProject/ReminderProject/Views/RegisterView/RegisterViewController.swift
@@ -49,6 +49,30 @@ final class RegisterViewController: BaseViewController<RegisterView> {
         )
         
         baseView.memoView.textView.delegate = self
+        
+        baseView.dueDateTextField.trailingButton.addTarget(
+            self,
+            action: #selector(dueDateTextFieldTrailingButtonTapped),
+            for: .touchUpInside
+        )
+        
+        baseView.tagTextField.trailingButton.addTarget(
+            self,
+            action: #selector(tagTextFieldTrailingButtonTapped),
+            for: .touchUpInside
+        )
+        
+        baseView.priorityTextField.trailingButton.addTarget(
+            self,
+            action: #selector(priorityTextFieldTrailingButtonTapped),
+            for: .touchUpInside
+        )
+        
+        baseView.imageTextField.trailingButton.addTarget(
+            self,
+            action: #selector(imageTextFieldTrailingButtonTapped),
+            for: .touchUpInside
+        )
     }
     
     @objc
@@ -58,6 +82,50 @@ final class RegisterViewController: BaseViewController<RegisterView> {
         } else {
             rightBarButton.isEnabled = false
         }
+    }
+    
+    @objc
+    func dueDateTextFieldTrailingButtonTapped(_ sender: UIButton) {
+        print(#function)
+        let vc = DetailInputViewController(baseView: DetailInputView())
+        
+        vc.configureData(.dueDate)
+        vc.delegate = self
+        
+        navigationController?.pushViewController(vc, animated: true)
+        
+        // MARK: present된 vc에서는 navigationManager를 이용한 push가 안됨
+//        NavigationManager.shared.pushVC(vc, animated: true)
+    }
+    
+    @objc
+    func tagTextFieldTrailingButtonTapped(_ sender: UIButton) {
+        let vc = DetailInputViewController(baseView: DetailInputView())
+        
+        vc.configureData(.tag)
+        vc.delegate = self
+        
+        navigationController?.pushViewController(vc, animated: true)
+    }
+    
+    @objc
+    func priorityTextFieldTrailingButtonTapped(_ sender: UIButton) {
+        let vc = DetailInputViewController(baseView: DetailInputView())
+        
+        vc.configureData(.priority)
+        vc.delegate = self
+        
+        navigationController?.pushViewController(vc, animated: true)
+    }
+    
+    @objc
+    func imageTextFieldTrailingButtonTapped(_ sender: UIButton) {
+        let vc = DetailInputViewController(baseView: DetailInputView())
+        
+        vc.configureData(.image)
+        vc.delegate = self
+        
+        navigationController?.pushViewController(vc, animated: true)
     }
     
     @objc
@@ -73,12 +141,20 @@ final class RegisterViewController: BaseViewController<RegisterView> {
         }
         
         let content = baseView.memoView.textView.text
+        let dueDate = baseView.dueDateTextField.content.text ?? ""
+        let tag = baseView.tagTextField.content.text
+        let priority = Int(baseView.priorityTextField.content.text ?? "0")
+        
         
         RealmManager.shared.create(Todos(
             title: title,
+            content: content, 
             category: "식품",
-            content: content
+            dueDate: DateHelper.shared.date(from: dueDate),
+            tag: tag,
+            priority: priority
         ))
+        
         NavigationManager.shared.dismiss(animated: true)
     }
 }
@@ -86,5 +162,20 @@ final class RegisterViewController: BaseViewController<RegisterView> {
 extension RegisterViewController: UITextViewDelegate {
     func textViewDidBeginEditing(_ textView: UITextView) {
         textView.text = ""
+    }
+}
+
+extension RegisterViewController: DetailInputDelegate {
+    func sendDetailData(_ type: RegisterFieldType, text: String) {
+        switch type {
+        case .dueDate:
+            baseView.dueDateTextField.content.text = text
+        case .tag:
+            baseView.tagTextField.content.text = text
+        case .priority:
+            baseView.priorityTextField.content.text = text
+        case .image:
+            baseView.imageTextField.content.text = text
+        }
     }
 }


### PR DESCRIPTION
## 🌱 *Pull requests*

🌿 **작업한 브랜치**
https://github.com/alpaka99/Reminder-Project/tree/%2313/Feat/Implement-Detail-Memo

<br></br>

## 🔍 **작업한 결과**
- [x] 제목, 내용, 마감일, 태그, 우선순위를 모두 Realm Column에 저장할 수 있게 Realm DB Migration을 진행합니다
- [x] RegisterView에서 제목, 내용, 마감일, 태그, 우선순위를 모두 저장할 수 있도록 합니다

<br></br>
## 🔫 **Trouble Shooting**
- #12 에서 진행한 리팩터링이 의미가 있다고 느껴졌습니다.
-  DetailInputViewController 하나에서 다양한 input 작업들을 처리해주고 싶어서, RegisterFieldType이라는 enum을 생성하고, 해당 enum에 맞춰서 하나의 DetailInputView의 UI와 로직이 변경되는 형태로 만들었습니다.
- RegisterViewController에서 '추가' 버튼을 누를때 Realm에 저장하는 방식이기 때문에, RegisterViewController가 DetailInputViewController의 delegate로서 데이터를 전달받아 realm에 저장하는 역할을 하고 있습니다. 


<br></br>
## 🔊 기타 공유사항
- Realm Schema Version이 2로 되었습니다. 딱히 migration 과정에서 migrationBlock에서 조정해줄 값들은 없지만, column이 늘어나는 수정사항이 생겨 버전도 증가하였습니다.

<br></br>
## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|마감일 테스트|![Simulator Screen Recording - iPhone 15 Pro - 2024-07-04 at 03 45 56](https://github.com/alpaka99/Reminder-Project/assets/22471820/58ae63f1-b23e-41c1-9c26-648d3b1df64a)|
|태그 테스트|![Simulator Screen Recording - iPhone 15 Pro - 2024-07-04 at 03 46 22](https://github.com/alpaka99/Reminder-Project/assets/22471820/d1546a7e-6964-4d22-8b1b-8bffc27676f6)|
|우선 순위 테스트| ![Simulator Screen Recording - iPhone 15 Pro - 2024-07-04 at 03 56 28](https://github.com/alpaka99/Reminder-Project/assets/22471820/3d991756-a061-40c8-bcd1-9e7860077304)|
|전체 테스트| ![Simulator Screen Recording - iPhone 15 Pro - 2024-07-04 at 03 57 03](https://github.com/alpaka99/Reminder-Project/assets/22471820/20c554d9-4740-4c04-9030-0c38984dbf4d)|
<br></br>

## 📟 관련 이슈
- Resolved: #13 
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 