### PR TITLE
#15/feat/implement read views

### DIFF
--- a/ReminderProject/ReminderProject.xcodeproj/project.pbxproj
+++ b/ReminderProject/ReminderProject.xcodeproj/project.pbxproj
@@ -42,6 +42,8 @@
 		CED1E0D32C35B125004BFBE1 /* DetailInputViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E0D22C35B125004BFBE1 /* DetailInputViewController.swift */; };
 		CED1E0D62C35B151004BFBE1 /* DetailInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E0D52C35B151004BFBE1 /* DetailInputView.swift */; };
 		CED1E0D82C35C851004BFBE1 /* DateHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E0D72C35C851004BFBE1 /* DateHelper.swift */; };
+		CED1E0DB2C360BA6004BFBE1 /* DetailTodoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E0DA2C360BA6004BFBE1 /* DetailTodoView.swift */; };
+		CED1E0DD2C360BFE004BFBE1 /* DetailTodoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E0DC2C360BFE004BFBE1 /* DetailTodoViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -80,6 +82,8 @@
 		CED1E0D22C35B125004BFBE1 /* DetailInputViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailInputViewController.swift; sourceTree = "<group>"; };
 		CED1E0D52C35B151004BFBE1 /* DetailInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailInputView.swift; sourceTree = "<group>"; };
 		CED1E0D72C35C851004BFBE1 /* DateHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateHelper.swift; sourceTree = "<group>"; };
+		CED1E0DA2C360BA6004BFBE1 /* DetailTodoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailTodoView.swift; sourceTree = "<group>"; };
+		CED1E0DC2C360BFE004BFBE1 /* DetailTodoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailTodoViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -145,6 +149,7 @@
 		CED1E0952C33FA88004BFBE1 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				CED1E0D92C360B89004BFBE1 /* DetailTodoView */,
 				CED1E0D42C35B13E004BFBE1 /* DetailInputViewController */,
 				CED1E0B72C345368004BFBE1 /* ListView */,
 				CED1E0AA2C34153F004BFBE1 /* RegisterView */,
@@ -248,6 +253,15 @@
 			path = DetailInputViewController;
 			sourceTree = "<group>";
 		};
+		CED1E0D92C360B89004BFBE1 /* DetailTodoView */ = {
+			isa = PBXGroup;
+			children = (
+				CED1E0DA2C360BA6004BFBE1 /* DetailTodoView.swift */,
+				CED1E0DC2C360BFE004BFBE1 /* DetailTodoViewController.swift */,
+			);
+			path = DetailTodoView;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -328,6 +342,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				CED1E0B42C341ED3004BFBE1 /* BaseTableViewCell.swift in Sources */,
+				CED1E0DD2C360BFE004BFBE1 /* DetailTodoViewController.swift in Sources */,
+				CED1E0DB2C360BA6004BFBE1 /* DetailTodoView.swift in Sources */,
 				CED1E0BB2C34538B004BFBE1 /* ListView.swift in Sources */,
 				CED1E0C02C346ABC004BFBE1 /* NavigationManager.swift in Sources */,
 				CED1E0D12C35ADA4004BFBE1 /* RegisterFieldType.swift in Sources */,

--- a/ReminderProject/ReminderProject/Views/DetailTodoView/DetailTodoView.swift
+++ b/ReminderProject/ReminderProject/Views/DetailTodoView/DetailTodoView.swift
@@ -1,0 +1,109 @@
+//
+//  DetailTodoView.swift
+//  ReminderProject
+//
+//  Created by user on 7/4/24.
+//
+
+import UIKit
+
+import SnapKit
+
+final class DetailTodoView: BaseView {
+    private let titleLabel = {
+        let label = UILabel()
+        
+        label.textColor = .white
+        label.font = .systemFont(ofSize: 16, weight: .semibold)
+        
+        return label
+    }()
+    
+    private let contentLebl = {
+        let label = UILabel()
+        
+        label.textColor = .white
+        label.font = .systemFont(ofSize: 16, weight: .semibold)
+        
+        return label
+    }()
+    
+    private let dueDateLabel = {
+        let label = UILabel()
+        
+        label.textColor = .white
+        label.font = .systemFont(ofSize: 16, weight: .semibold)
+        
+        return label
+    }()
+    
+    private let tagLabel = {
+        let label = UILabel()
+        
+        label.textColor = .white
+        label.font = .systemFont(ofSize: 16, weight: .semibold)
+        
+        return label
+    }()
+    
+    private let priorityLabel = {
+        let label = UILabel()
+        
+        label.textColor = .white
+        label.font = .systemFont(ofSize: 16, weight: .semibold)
+        
+        return label
+    }()
+    
+    private lazy var stackView = {
+        let stack = UIStackView(arrangedSubviews: [
+            titleLabel,
+            contentLebl,
+            dueDateLabel,
+            tagLabel,
+            priorityLabel
+        ])
+        
+        stack.axis = .vertical
+        stack.spacing = 16
+        stack.distribution = .equalSpacing
+        
+        return stack
+    }()
+    
+    private var todo: Todos
+    
+    init(todo: Todos) {
+        self.todo = todo
+        
+        super.init(frame: .zero)
+        
+        
+    }
+    
+    
+    override func configureHierarchy() {
+        super.configureHierarchy()
+        
+        self.addSubview(stackView)
+    }
+    
+    override func configureLayout() {
+        super.configureLayout()
+        
+        stackView.snp.makeConstraints {
+            $0.center.equalTo(self)
+                .inset(16)
+        }
+    }
+    
+    override func configureUI() {
+        super.configureUI()
+        
+        titleLabel.text = todo.title
+        contentLebl.text = todo.content
+        dueDateLabel.text = DateHelper.shared.string(from: todo.dueDate)
+        tagLabel.text = todo.tag
+        priorityLabel.text = String(describing: todo.priority)
+    }
+}

--- a/ReminderProject/ReminderProject/Views/DetailTodoView/DetailTodoViewController.swift
+++ b/ReminderProject/ReminderProject/Views/DetailTodoView/DetailTodoViewController.swift
@@ -1,0 +1,17 @@
+//
+//  DetailTodoViewController.swift
+//  ReminderProject
+//
+//  Created by user on 7/4/24.
+//
+
+import UIKit
+
+final class DetailTodoViewController: BaseViewController<DetailTodoView> {
+    
+    override func configureUI() {
+        super.configureUI()
+        
+        navigationItem.title = "Todo 상세 데이터"
+    }
+}

--- a/ReminderProject/ReminderProject/Views/ListView/ListViewController.swift
+++ b/ReminderProject/ReminderProject/Views/ListView/ListViewController.swift
@@ -94,6 +94,7 @@ extension ListViewController: UITableViewDelegate, UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: false)
+        
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {

--- a/ReminderProject/ReminderProject/Views/ListView/ListViewController.swift
+++ b/ReminderProject/ReminderProject/Views/ListView/ListViewController.swift
@@ -94,7 +94,9 @@ extension ListViewController: UITableViewDelegate, UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: false)
+        guard let data = results?[indexPath.row] else { return }
         
+        NavigationManager.shared.pushVC(DetailTodoViewController(baseView: DetailTodoView(todo: data)))
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {

--- a/ReminderProject/ReminderProject/Views/MainView/MainView.swift
+++ b/ReminderProject/ReminderProject/Views/MainView/MainView.swift
@@ -115,6 +115,6 @@ final class MainView: BaseView {
     
     @objc
     func addListButtonTapped() {
-        NavigationManager.shared.pushVC(ListViewController(baseView: ListView()))
+//        NavigationManager.shared.pushVC(ListViewController(baseView: ListView()))
     }
 }

--- a/ReminderProject/ReminderProject/Views/MainView/MainViewController.swift
+++ b/ReminderProject/ReminderProject/Views/MainView/MainViewController.swift
@@ -50,6 +50,12 @@ extension MainViewController: UICollectionViewDelegate, UICollectionViewDataSour
         
         return cell
     }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        collectionView.deselectItem(at: indexPath, animated: false)
+        
+        NavigationManager.shared.pushVC(ListViewController(baseView: ListView()), animated: true)
+    }
 }
 
 


### PR DESCRIPTION
## 🌱 *Pull requests*

🌿 **작업한 브랜치**
https://github.com/alpaka99/Reminder-Project/tree/%2315/Feat/Implement-Read-Views

<br></br>

## 🔍 **작업한 결과**
- ListView의 진입 경로를 MainView의 하단의 '목록 추가' 버튼이 아닌, MainView의 collectionView의 cell을 탭 했을때 이동하는 방법으로 변경했습니다.
- ListView의 tableView의 item을 탭 했을 때, 해당 todo의 상세 정보를 확인 할 수 있는 DetailTodoView로 이동합니다. 현재는 DetailTodoView에 대한 상세 UI 및 기능에 대한 명세가 없어서 단순한 StackView에 Todo의 정보들을 나열하고 있습니다.

<br></br>
## 🔫 **Trouble Shooting**


<br></br>
## 🔊 기타 공유사항
- 추후에 Category에 대한 상세 기능 명세등이 나오면, MainView에서 데이터를 분류하여 ListView로 전달하는 등의 기능을 생각할 수 있을것 같습니다. 이때 ListView에서도 데이터 변경이 일어날 수 있을텐데, Realm에 불필요하게 접근하여 연산을 늘리는것을 지양하도록 해야합니다.
- 또한 현재 ListView에서 RealmManager의 readAll(_:) 로 가져오는 전체 데이터는, MainViewController로 기능을 옮기고, ListVIew에서는 데이터를 전달만 받는것도 생각해볼 수 있을것 같습니다.

<br></br>
## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|수정된 App Flow|![Simulator Screen Recording - iPhone 15 Pro - 2024-07-04 at 08 03 47](https://github.com/alpaka99/Reminder-Project/assets/22471820/a39c5e05-7a7e-4218-82c8-45febafa4d33)|
<br></br>

## 📟 관련 이슈
- Resolved: #15 
