### PR TITLE
#20/feat/additional register view feature

### DIFF
--- a/ReminderProject/ReminderProject.xcodeproj/project.pbxproj
+++ b/ReminderProject/ReminderProject.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		CED1E1272C3840C6004BFBE1 /* CalendarAlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E1262C3840C6004BFBE1 /* CalendarAlertViewController.swift */; };
 		CED1E1292C3840CE004BFBE1 /* CalendarAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E1282C3840CE004BFBE1 /* CalendarAlertView.swift */; };
 		CED1E12B2C392962004BFBE1 /* TodoPriority.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E12A2C392962004BFBE1 /* TodoPriority.swift */; };
+		CED1E12F2C398C42004BFBE1 /* FileManager+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E12E2C398C42004BFBE1 /* FileManager+Extension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -94,6 +95,7 @@
 		CED1E1262C3840C6004BFBE1 /* CalendarAlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarAlertViewController.swift; sourceTree = "<group>"; };
 		CED1E1282C3840CE004BFBE1 /* CalendarAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarAlertView.swift; sourceTree = "<group>"; };
 		CED1E12A2C392962004BFBE1 /* TodoPriority.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoPriority.swift; sourceTree = "<group>"; };
+		CED1E12E2C398C42004BFBE1 /* FileManager+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+Extension.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -207,6 +209,7 @@
 				CED1E0CC2C356203004BFBE1 /* NSObject+Extension.swift */,
 				CED1E1212C36D6CA004BFBE1 /* UIColor+Extension.swift */,
 				CED1E1232C36D6FC004BFBE1 /* String+Extension.swift */,
+				CED1E12E2C398C42004BFBE1 /* FileManager+Extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -365,6 +368,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CED1E0B42C341ED3004BFBE1 /* BaseTableViewCell.swift in Sources */,
+				CED1E12F2C398C42004BFBE1 /* FileManager+Extension.swift in Sources */,
 				CED1E12B2C392962004BFBE1 /* TodoPriority.swift in Sources */,
 				CED1E0DD2C360BFE004BFBE1 /* DetailTodoViewController.swift in Sources */,
 				CED1E0DB2C360BA6004BFBE1 /* DetailTodoView.swift in Sources */,

--- a/ReminderProject/ReminderProject.xcodeproj/project.pbxproj
+++ b/ReminderProject/ReminderProject.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		CED1E1242C36D6FC004BFBE1 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E1232C36D6FC004BFBE1 /* String+Extension.swift */; };
 		CED1E1272C3840C6004BFBE1 /* CalendarAlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E1262C3840C6004BFBE1 /* CalendarAlertViewController.swift */; };
 		CED1E1292C3840CE004BFBE1 /* CalendarAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E1282C3840CE004BFBE1 /* CalendarAlertView.swift */; };
+		CED1E12B2C392962004BFBE1 /* TodoPriority.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E12A2C392962004BFBE1 /* TodoPriority.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -92,6 +93,7 @@
 		CED1E1232C36D6FC004BFBE1 /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
 		CED1E1262C3840C6004BFBE1 /* CalendarAlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarAlertViewController.swift; sourceTree = "<group>"; };
 		CED1E1282C3840CE004BFBE1 /* CalendarAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarAlertView.swift; sourceTree = "<group>"; };
+		CED1E12A2C392962004BFBE1 /* TodoPriority.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoPriority.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -184,6 +186,7 @@
 				CED1E0A82C340DEE004BFBE1 /* TodoCategory.swift */,
 				CED1E0D02C35ADA4004BFBE1 /* RegisterFieldType.swift */,
 				CED1E0D72C35C851004BFBE1 /* DateHelper.swift */,
+				CED1E12A2C392962004BFBE1 /* TodoPriority.swift */,
 			);
 			path = Constants;
 			sourceTree = "<group>";
@@ -362,6 +365,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CED1E0B42C341ED3004BFBE1 /* BaseTableViewCell.swift in Sources */,
+				CED1E12B2C392962004BFBE1 /* TodoPriority.swift in Sources */,
 				CED1E0DD2C360BFE004BFBE1 /* DetailTodoViewController.swift in Sources */,
 				CED1E0DB2C360BA6004BFBE1 /* DetailTodoView.swift in Sources */,
 				CED1E1222C36D6CA004BFBE1 /* UIColor+Extension.swift in Sources */,

--- a/ReminderProject/ReminderProject/Constants/TodoPriority.swift
+++ b/ReminderProject/ReminderProject/Constants/TodoPriority.swift
@@ -1,0 +1,54 @@
+//
+//  TodoPriority.swift
+//  ReminderProject
+//
+//  Created by user on 7/6/24.
+//
+
+enum TodoPriority: Int, CaseIterable {
+    case high = 0
+    case medium
+    case low
+    
+    static var allContents: [String] {
+        let allCases = Self.allCases
+        var allContents: [String] = []
+        
+        allCases.forEach { priority in
+            allContents.append(priority.content)
+        }
+        
+        return allContents
+    }
+    
+    static func intInit(rawString: String) -> Self? {
+        guard let rawValue = Int(rawString) else { return nil }
+        
+        return Self.init(rawValue: rawValue)
+    }
+    
+    static func stringInit(rawString: String) -> Self? {
+        switch rawString {
+        case "High🔴":
+            return .high
+        case "Medium🟡":
+            return .medium
+        case "Low🟣":
+            return .low
+        default:
+            return nil
+        }
+    }
+    
+    
+    var content: String {
+        switch self {
+        case .high:
+            return "High🔴"
+        case .medium:
+            return "Medium🟡"
+        case .low:
+            return "Low🟣"
+        }
+    }
+}

--- a/ReminderProject/ReminderProject/Extensions/FileManager+Extension.swift
+++ b/ReminderProject/ReminderProject/Extensions/FileManager+Extension.swift
@@ -1,0 +1,59 @@
+//
+//  FileManager+Extension.swift
+//  ReminderProject
+//
+//  Created by user on 7/6/24.
+//
+
+import UIKit
+
+extension UIViewController {
+    func saveImageToDocument(image: UIImage, fileName: String) {
+        // 1. document directory 찾아가기
+        guard let documentDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
+            print("DocumentDirectory Finding error")
+            return
+        }
+        
+        // 2. 이미지 저장할 경로 지정
+        let fileURL = documentDirectory.appendingPathComponent("\(fileName).jpeg")
+        
+        // 3. 이미지 압축
+        guard let data = image.jpegData(compressionQuality: 0.75) else {
+            print("Image Compression Error")
+            return
+        }
+        
+        // 이미지 저장
+        do {
+            try data.write(to: fileURL)
+        } catch {
+            print("File Save Failure")
+            print(error.localizedDescription)
+        }
+    }
+    
+    func deleteImageFromDocument(fileName: String) {
+        // 1. documentPath(base URL) 찾기
+        guard let path = FileManager.default.urls(
+            for: .applicationDirectory,
+            in: .userDomainMask
+        ).first else {
+            print("DocumentPath Finding Error")
+            return
+        }
+        
+        // 2. 정확한 url 만들기
+        let fileURL = path.appendingPathComponent("\(fileName).jpeg")
+        
+        // 3. 해당 url에 파일이 있는지 확인하고
+        if FileManager.default.fileExists(atPath: fileURL.path()) {
+            do {
+                try FileManager.default.removeItem(at: fileURL)
+            } catch {
+                print("File Deletion Error")
+                print(error)
+            }
+        }
+    }
+}

--- a/ReminderProject/ReminderProject/Views/CalendarAlertView/CalendarAlertViewController.swift
+++ b/ReminderProject/ReminderProject/Views/CalendarAlertView/CalendarAlertViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 final class CalendarAlertViewController: BaseViewController<CalendarAlertView> {
     
     weak var delegate: CalendarAlertViewControllerDelegate?
+    var currentDate = Date.now
     
     override func configureUI() {
         super.configureUI()
@@ -44,6 +45,7 @@ final class CalendarAlertViewController: BaseViewController<CalendarAlertView> {
     }
     
     @objc func conformButtonTapped() {
+        delegate?.conformButtonTapped(to: currentDate)
         dismiss(animated: true)
     }
     
@@ -57,9 +59,9 @@ extension CalendarAlertViewController: UICalendarViewDelegate, UICalendarSelecti
     func dateSelection(_ selection: UICalendarSelectionSingleDate, didSelectDate dateComponents: DateComponents?) {
         guard let dateComponents = dateComponents else { return }
         
-        guard let date = Calendar.current.date(from: dateComponents) else { return }
+        guard let selectedDate = Calendar.current.date(from: dateComponents) else { return }
         
-        delegate?.conformButtonTapped(to: date)
+        currentDate = selectedDate
     }
 }
 

--- a/ReminderProject/ReminderProject/Views/DetailInputView/DetailInputView.swift
+++ b/ReminderProject/ReminderProject/Views/DetailInputView/DetailInputView.swift
@@ -15,10 +15,11 @@ final class DetailInputView: BaseView {
     let datePicker = {
         let datePicker = UIDatePicker(frame: .zero)
         datePicker.datePickerMode = .date
-        
+        datePicker.preferredDatePickerStyle = .inline
         
         datePicker.backgroundColor = .white
         datePicker.alpha = 0
+        datePicker.layer.cornerRadius = 8
         
         return datePicker
     }()
@@ -28,6 +29,7 @@ final class DetailInputView: BaseView {
         
         textField.backgroundColor = .darkGray
         textField.layer.cornerRadius = 8
+        textField.placeholder = "태그를 입력해주세요"
         textField.alpha = 0
         
         return textField
@@ -66,28 +68,26 @@ final class DetailInputView: BaseView {
         
         datePicker.snp.makeConstraints {
             $0.center.equalTo(self)
-            $0.height.equalTo(50)
             $0.width.equalTo(self.snp.width)
                 .multipliedBy(0.8)
         }
         
         textField.snp.makeConstraints {
             $0.center.equalTo(self)
-            $0.height.equalTo(50)
             $0.width.equalTo(self.snp.width)
                 .multipliedBy(0.8)
+            $0.height.equalTo(50)
         }
         
         segmentedControl.snp.makeConstraints {
             $0.center.equalTo(self)
-            $0.height.equalTo(50)
             $0.width.equalTo(self.snp.width)
                 .multipliedBy(0.8)
+            $0.height.equalTo(50)
         }
         
         imagePicker.snp.makeConstraints {
             $0.center.equalTo(self)
-            $0.height.equalTo(50)
             $0.width.equalTo(self.snp.width)
                 .multipliedBy(0.8)
         }
@@ -117,7 +117,7 @@ final class DetailInputView: BaseView {
             return date
         case .tag:
             if let text = textField.text {
-                return text
+                return "#" + text
             }
         case .priority:
             return String(segmentedControl.selectedSegmentIndex)

--- a/ReminderProject/ReminderProject/Views/DetailInputView/DetailInputView.swift
+++ b/ReminderProject/ReminderProject/Views/DetailInputView/DetailInputView.swift
@@ -36,7 +36,7 @@ final class DetailInputView: BaseView {
     }()
     
     let segmentedControl = {
-        let segmentedControl = UISegmentedControl(items: ["High🔴", "Middle🟡", "Low🟣"])
+        let segmentedControl = UISegmentedControl(items: TodoPriority.allContents)
         
         segmentedControl.backgroundColor = .darkGray
         segmentedControl.selectedSegmentIndex = 0
@@ -120,7 +120,7 @@ final class DetailInputView: BaseView {
                 return "#" + text
             }
         case .priority:
-            return String(segmentedControl.selectedSegmentIndex)
+            return TodoPriority.init(rawValue: segmentedControl.selectedSegmentIndex)?.content ?? ""
         case .image:
             return "Comming Soon"
         }

--- a/ReminderProject/ReminderProject/Views/DetailInputView/DetailInputView.swift
+++ b/ReminderProject/ReminderProject/Views/DetailInputView/DetailInputView.swift
@@ -45,22 +45,12 @@ final class DetailInputView: BaseView {
         return segmentedControl
     }()
     
-    let imagePicker = {
-        let label = UILabel()
-        
-        label.text = "Comming soon..."
-        label.alpha = 0
-        
-        return label
-    }()
-    
     override func configureHierarchy() {
         super.configureHierarchy()
         
         self.addSubview(datePicker)
         self.addSubview(textField)
         self.addSubview(segmentedControl)
-        self.addSubview(imagePicker)
     }
     
     override func configureLayout() {
@@ -85,12 +75,6 @@ final class DetailInputView: BaseView {
                 .multipliedBy(0.8)
             $0.height.equalTo(50)
         }
-        
-        imagePicker.snp.makeConstraints {
-            $0.center.equalTo(self)
-            $0.width.equalTo(self.snp.width)
-                .multipliedBy(0.8)
-        }
     }
     
     
@@ -105,7 +89,7 @@ final class DetailInputView: BaseView {
         case .priority:
             segmentedControl.alpha = 1
         case .image:
-            imagePicker.alpha = 1
+            break
         }
     }
     
@@ -122,7 +106,7 @@ final class DetailInputView: BaseView {
         case .priority:
             return TodoPriority.init(rawValue: segmentedControl.selectedSegmentIndex)?.content ?? ""
         case .image:
-            return "Comming Soon"
+            return "Wrong Access to DetailInputView"
         }
         
         return ""

--- a/ReminderProject/ReminderProject/Views/DetailInputView/DetailInputView.swift
+++ b/ReminderProject/ReminderProject/Views/DetailInputView/DetailInputView.swift
@@ -116,7 +116,7 @@ final class DetailInputView: BaseView {
             guard let date = DateHelper.shared.string(from: datePicker.date) else { return "" }
             return date
         case .tag:
-            if let text = textField.text {
+            if let text = textField.text, !text.isEmpty {
                 return "#" + text
             }
         case .priority:

--- a/ReminderProject/ReminderProject/Views/DetailInputView/DetailInputViewController.swift
+++ b/ReminderProject/ReminderProject/Views/DetailInputView/DetailInputViewController.swift
@@ -10,12 +10,14 @@ import UIKit
 final class DetailInputViewController: BaseViewController<DetailInputView> {
     private var type: RegisterFieldType? = .dueDate
     
-    weak var delegate: DetailInputDelegate?
+    weak var delegate: DetailInputViewControllerDelegate?
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         
         guard let type = type else { return }
+        
+        
         let detailData = baseView.sendDetailData()
         
         delegate?.sendDetailData(type, text: detailData)
@@ -32,15 +34,10 @@ final class DetailInputViewController: BaseViewController<DetailInputView> {
     internal func configureData(_ type: RegisterFieldType) {
         self.type = type
     }
-    
-//    @objc
-//    func completeButtonTapped() {
-//        navigationController?.popViewController(animated: true)
-//    }
 }
 
 
-protocol DetailInputDelegate: AnyObject {
+protocol DetailInputViewControllerDelegate: AnyObject {
     func sendDetailData(_ type: RegisterFieldType, text: String)
 }
 

--- a/ReminderProject/ReminderProject/Views/DetailInputView/DetailInputViewController.swift
+++ b/ReminderProject/ReminderProject/Views/DetailInputView/DetailInputViewController.swift
@@ -27,20 +27,20 @@ final class DetailInputViewController: BaseViewController<DetailInputView> {
         guard let type = type else { return }
         baseView.configureData(type)
         
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "완료", style: .plain, target: self, action: #selector(completeButtonTapped))
     }
     
     internal func configureData(_ type: RegisterFieldType) {
         self.type = type
     }
     
-    @objc
-    func completeButtonTapped() {
-        navigationController?.popViewController(animated: true)
-    }
+//    @objc
+//    func completeButtonTapped() {
+//        navigationController?.popViewController(animated: true)
+//    }
 }
 
 
 protocol DetailInputDelegate: AnyObject {
     func sendDetailData(_ type: RegisterFieldType, text: String)
 }
+

--- a/ReminderProject/ReminderProject/Views/MainView/MainViewController.swift
+++ b/ReminderProject/ReminderProject/Views/MainView/MainViewController.swift
@@ -109,7 +109,7 @@ final class MainViewController: BaseViewController<MainView> {
     }
     
     @objc func rightBarButtonTapped() {
-        print(#function)
+        
     }
     
     

--- a/ReminderProject/ReminderProject/Views/RegisterView/RegisterDisclosureCell.swift
+++ b/ReminderProject/ReminderProject/Views/RegisterView/RegisterDisclosureCell.swift
@@ -28,6 +28,15 @@ final class RegisterDisclosureCell: BaseView {
         return label
     }()
     
+    let thumbnailImage = {
+        let imageView = UIImageView()
+        
+        imageView.contentMode = .scaleToFill
+        imageView.clipsToBounds = true
+        
+        return imageView
+    }()
+    
     let trailingButton = {
         let button = UIButton()
         
@@ -42,6 +51,7 @@ final class RegisterDisclosureCell: BaseView {
         
         self.addSubview(title)
         self.addSubview(content)
+        self.addSubview(thumbnailImage)
         self.addSubview(trailingButton)
     }
     
@@ -55,13 +65,6 @@ final class RegisterDisclosureCell: BaseView {
                 .inset(16)
         }
         
-        content.snp.makeConstraints {
-            $0.leading.equalTo(title.snp.trailing)
-                .offset(16)
-            $0.verticalEdges.equalTo(self.snp.verticalEdges)
-                .inset(16)
-        }
-        
         trailingButton.snp.makeConstraints {
             $0.verticalEdges.equalTo(self.snp.verticalEdges)
                 .inset(16)
@@ -70,6 +73,24 @@ final class RegisterDisclosureCell: BaseView {
             $0.width.equalTo(trailingButton.snp.height)
                 .multipliedBy(1)
         }
+        
+        content.snp.makeConstraints {
+            $0.trailing.equalTo(trailingButton.snp.leading)
+                .offset(-16)
+            $0.verticalEdges.equalTo(self.snp.verticalEdges)
+                .inset(16)
+        }
+        
+        thumbnailImage.snp.makeConstraints {
+            $0.verticalEdges.equalTo(self.snp.verticalEdges)
+                .inset(8)
+            $0.trailing.equalTo(content.snp.leading)
+                .offset(-16)
+            
+            $0.size.equalTo(44)
+        }
+        
+        
     }
     
     override func configureUI() {
@@ -78,9 +99,6 @@ final class RegisterDisclosureCell: BaseView {
         self.backgroundColor = .darkGray
         self.layer.cornerRadius = 8
         self.clipsToBounds = true
-        
-        title.textColor = .systemGray4
-        title.font = .systemFont(ofSize: 16, weight: .semibold)
     }
     
     func configureData(_ text: String) {

--- a/ReminderProject/ReminderProject/Views/RegisterView/RegisterViewController.swift
+++ b/ReminderProject/ReminderProject/Views/RegisterView/RegisterViewController.swift
@@ -88,7 +88,6 @@ final class RegisterViewController: BaseViewController<RegisterView> {
     
     @objc
     func dueDateTextFieldTrailingButtonTapped(_ sender: UIButton) {
-        print(#function)
         let vc = DetailInputViewController(baseView: DetailInputView())
         
         vc.configureData(.dueDate)

--- a/ReminderProject/ReminderProject/Views/RegisterView/RegisterViewController.swift
+++ b/ReminderProject/ReminderProject/Views/RegisterView/RegisterViewController.swift
@@ -142,15 +142,19 @@ final class RegisterViewController: BaseViewController<RegisterView> {
         }
         
         let content = baseView.memoView.textView.text
-        let dueDate = baseView.dueDateTextField.content.text ?? ""
-        let tag = baseView.tagTextField.content.text
-        let priority = Int(baseView.priorityTextField.content.text ?? "0")
         
+        let unFormattedDueDate = baseView.dueDateTextField.content.text ?? ""
+        let dueDate = DateHelper.shared.date(from: unFormattedDueDate)
+        
+        let tag = baseView.tagTextField.content.text
+        
+        let unConvertedPriority = baseView.priorityTextField.content.text ?? ""
+        let priority = TodoPriority.stringInit(rawString: unConvertedPriority)?.rawValue
         
         RealmManager.shared.create(Todo(
             title: title,
             content: content, 
-            dueDate: DateHelper.shared.date(from: dueDate),
+            dueDate: dueDate,
             tag: tag,
             priority: priority
         ))
@@ -167,7 +171,7 @@ extension RegisterViewController: UITextViewDelegate {
     }
 }
 
-extension RegisterViewController: DetailInputDelegate {
+extension RegisterViewController: DetailInputViewControllerDelegate {
     func sendDetailData(_ type: RegisterFieldType, text: String) {
         switch type {
         case .dueDate:


### PR DESCRIPTION
## 🌱 *Pull requests*

🌿 **작업한 브랜치**
https://github.com/alpaka99/Reminder-Project/tree/%2320/Feat/Additional-RegisterView-Feature

<br></br>

## 🔍 **작업한 결과**
- [x] 마감일, 태그, 우선순위, 이미지 추가를 누르면 뷰 컨트롤러가 push됩니다
- [x] 마감일 화면은 DatePicker가 있고, 뒤로가기를 누르면 설정한 날짜가 등록 화면에 반영됩니다
- [x] 태그 화면은 textField가 하나 있고, 뒤로가기를 누르면 작성한 문자열이 등록 화면에 반영됩니다
- [x] 우선 순위 화면은 SegmentedControl 하나만 있고, 뒤로가기를 누르면 세그먼트 컨트롤에서 선택한 값이 등록 화면에 반영됩니다.
- [x] 이미지 추가 버튼을 누르면 갤러리가 보여지고, 선택한 이미지가 셀 우측에 보여집니다

<br></br>
## 🔫 **Trouble Shooting**
- Realm 데이터의 형태가 바뀌면서 변경점이 생겼습니다.
- 추후에 priority로 sort하기 위해서 단순 string이 아닌 int 타입으로 저장합니다. 따라서 TodoPriority라는 enum을 생성하여 변환을 하려고 하고 있습니다.
- PHPhotopicker를 이용하여 이미지를 갤러리로부터 불러옵니다. 이미지 저장할때의 이름은 todo 객체의 id값을 따라가서 유일하면서도 간편하게 저장할 수 있게 하였습니다.
- 불러온 이미지는 cell의 thumbnailImage로 볼 수 있도록 하였습니다.
- 이미지의 저장은 앱의 documents 폴더에 저장할 수 있게 하였습니다.
- 현재는 이미지를 하나만 저장할 수 있지만, 추후에는 여러개의 이미지를 저장하는 방식도 생각해볼 수 있겠습니다.

<br></br>
## 🔊 기타 공유사항
<!-- Any Information To Share -->

<br></br>
## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|마감일 기능|![Simulator Screen Recording - iPhone 15 Pro - 2024-07-06 at 01 45 02](https://github.com/alpaka99/Reminder-Project/assets/22471820/9b001089-3161-40aa-818a-12431e2bc080)|
|태그 기능| ![Simulator Screen Recording - iPhone 15 Pro - 2024-07-07 at 00 11 56](https://github.com/alpaka99/Reminder-Project/assets/22471820/079f9c1d-4892-4a6a-a724-1a1b1e3f224a)|
|우선 순위 기능| ![Simulator Screen Recording - iPhone 15 Pro - 2024-07-07 at 00 10 30](https://github.com/alpaka99/Reminder-Project/assets/22471820/b91a9210-cdde-4710-a3d7-a15a98cf7ac2)|
|이미지 기능|![Simulator Screen Recording - iPhone 15 Pro - 2024-07-07 at 00 12 10](https://github.com/alpaka99/Reminder-Project/assets/22471820/24f3a290-83c3-470c-b1cd-451cdcba5486)|


<br></br>

## 📟 관련 이슈
- Resolved: #20 
