### PR TITLE
#22/feat/additional list view featrues

### DIFF
--- a/ReminderProject/ReminderProject.xcodeproj/project.pbxproj
+++ b/ReminderProject/ReminderProject.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		CED1E1292C3840CE004BFBE1 /* CalendarAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E1282C3840CE004BFBE1 /* CalendarAlertView.swift */; };
 		CED1E12B2C392962004BFBE1 /* TodoPriority.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E12A2C392962004BFBE1 /* TodoPriority.swift */; };
 		CED1E12F2C398C42004BFBE1 /* FileManager+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E12E2C398C42004BFBE1 /* FileManager+Extension.swift */; };
+		CED1E1312C3A9882004BFBE1 /* Bool+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E1302C3A9882004BFBE1 /* Bool+Extension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -96,6 +97,7 @@
 		CED1E1282C3840CE004BFBE1 /* CalendarAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarAlertView.swift; sourceTree = "<group>"; };
 		CED1E12A2C392962004BFBE1 /* TodoPriority.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoPriority.swift; sourceTree = "<group>"; };
 		CED1E12E2C398C42004BFBE1 /* FileManager+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+Extension.swift"; sourceTree = "<group>"; };
+		CED1E1302C3A9882004BFBE1 /* Bool+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bool+Extension.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -210,6 +212,7 @@
 				CED1E1212C36D6CA004BFBE1 /* UIColor+Extension.swift */,
 				CED1E1232C36D6FC004BFBE1 /* String+Extension.swift */,
 				CED1E12E2C398C42004BFBE1 /* FileManager+Extension.swift */,
+				CED1E1302C3A9882004BFBE1 /* Bool+Extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -397,6 +400,7 @@
 				CED1E0CD2C356203004BFBE1 /* NSObject+Extension.swift in Sources */,
 				CED1E09D2C33FEF9004BFBE1 /* Constants.swift in Sources */,
 				CED1E0732C33E79C004BFBE1 /* AppDelegate.swift in Sources */,
+				CED1E1312C3A9882004BFBE1 /* Bool+Extension.swift in Sources */,
 				CED1E0B92C345386004BFBE1 /* ListViewController.swift in Sources */,
 				CED1E0D32C35B125004BFBE1 /* DetailInputViewController.swift in Sources */,
 				CED1E0AC2C341555004BFBE1 /* RegisterViewController.swift in Sources */,

--- a/ReminderProject/ReminderProject/Constants/TodoPriority.swift
+++ b/ReminderProject/ReminderProject/Constants/TodoPriority.swift
@@ -51,4 +51,15 @@ enum TodoPriority: Int, CaseIterable {
             return "Low🟣"
         }
     }
+    
+    var emoji: String {
+        switch self {
+        case .high:
+            return "🔴"
+        case .medium:
+            return "🟡"
+        case .low:
+            return "🟣"
+        }
+    }
 }

--- a/ReminderProject/ReminderProject/Extensions/Bool+Extension.swift
+++ b/ReminderProject/ReminderProject/Extensions/Bool+Extension.swift
@@ -1,0 +1,12 @@
+//
+//  Bool+Extension.swift
+//  ReminderProject
+//
+//  Created by user on 7/7/24.
+//
+
+extension Bool {
+    func toggled() -> Self {
+        return self ? false : true
+    }
+}

--- a/ReminderProject/ReminderProject/Managers/RealmManager.swift
+++ b/ReminderProject/ReminderProject/Managers/RealmManager.swift
@@ -36,15 +36,40 @@ final class RealmManager {
         return result
     }
     
-    // MARK: Update
-    internal func update<T: Object> (with newValue: T) {
+    // MARK: Update to new Object
+    internal func update<T: Object>(to newValue: T) {
         do {
-            let target = realm.object(ofType: T.self, forPrimaryKey: newValue.objectSchema.primaryKeyProperty)
+            let target = realm.object(
+                ofType: T.self,
+                forPrimaryKey: newValue.objectSchema.primaryKeyProperty
+            )
+            
             try realm.write {
-                realm.add(newValue, update: .modified)
+                realm.create(
+                    T.self,
+                    value: newValue,
+                    update: .modified
+                )
             }
         } catch {
             print("Realm Update Error")
+            print(error.localizedDescription)
+        }
+    }
+    
+    internal func updateFlaged<T: Todo>(from oldValue: T) {
+        do {
+            let target = realm.object(
+                ofType: T.self,
+                forPrimaryKey: oldValue._id
+            )
+            guard let target = target else { return }
+            
+            try realm.write {
+                target.setValue(target.flaged.toggled(), forKey: "flaged")
+            }
+        } catch {
+            print("FlagValue Update Error")
             print(error.localizedDescription)
         }
     }

--- a/ReminderProject/ReminderProject/Managers/RealmManager.swift
+++ b/ReminderProject/ReminderProject/Managers/RealmManager.swift
@@ -57,7 +57,7 @@ final class RealmManager {
         }
     }
     
-    internal func updateFlaged<T: Todo>(from oldValue: T) {
+    internal func toggleFlaged<T: Todo>(of oldValue: T) {
         do {
             let target = realm.object(
                 ofType: T.self,
@@ -70,6 +70,23 @@ final class RealmManager {
             }
         } catch {
             print("FlagValue Update Error")
+            print(error.localizedDescription)
+        }
+    }
+    
+    internal func toggleCompleted<T: Todo>(of oldValue: T) {
+        do {
+            let target = realm.object(
+                ofType: T.self,
+                forPrimaryKey: oldValue._id
+            )
+            guard let target = target else { return }
+            
+            try realm.write {
+                target.setValue(target.completed.toggled(), forKey: "completed")
+            }
+        } catch {
+            print("Completed Update Error")
             print(error.localizedDescription)
         }
     }

--- a/ReminderProject/ReminderProject/Models/RealmModels/Todo.swift
+++ b/ReminderProject/ReminderProject/Models/RealmModels/Todo.swift
@@ -37,4 +37,10 @@ final class Todo: Object {
         self.tag = tag
         self.priority = priority
     }
+    
+    var useThisToFilterDate: Date? {
+        guard let dueDate = self.dueDate else { return  nil }
+        
+        return dueDate
+    }
 }

--- a/ReminderProject/ReminderProject/Views/ListView/ListTableViewCell.swift
+++ b/ReminderProject/ReminderProject/Views/ListView/ListTableViewCell.swift
@@ -104,7 +104,9 @@ final class ListTableViewCell: BaseTableViewCell {
         title.text = data.title
         content.text = data.content
         dateLabel.text = DateHelper.shared.string(from: data.dueDate)
-        priority.text = String(data.priority ?? -1)
+        if let priorityInt = data.priority, let priorityEmoji = TodoPriority.init(rawValue: priorityInt)?.emoji {
+            priority.text = priorityEmoji
+        }
         tagLabel.text = data.tag
     }
 }

--- a/ReminderProject/ReminderProject/Views/ListView/ListTableViewCell.swift
+++ b/ReminderProject/ReminderProject/Views/ListView/ListTableViewCell.swift
@@ -14,6 +14,14 @@ final class ListTableViewCell: BaseTableViewCell {
     private let content = UILabel()
     private let dateLabel = UILabel()
     private let tagLabel = UILabel()
+    private var attributedContainer = {
+        var container = AttributeContainer()
+        
+        container.strikethroughStyle = .none
+        container.font = .systemFont(ofSize: 16, weight: .semibold)
+        
+        return container
+    }()
     
     override func configureHierarchy() {
         super.configureHierarchy()
@@ -79,13 +87,12 @@ final class ListTableViewCell: BaseTableViewCell {
         
         self.backgroundColor = .clear
         
-        toggleButton.setImage(UIImage(systemName: "circle"), for: .normal)
+        var config = UIButton.Configuration.plain()
+        config.image = UIImage(systemName: "circle")
+        toggleButton.configuration = config
         
         priority.font = .systemFont(ofSize: 16, weight: .semibold)
         priority.textColor = .white
-        
-        title.font = .systemFont(ofSize: 16, weight: .semibold)
-        title.textColor = .white
         
         
         content.font = .systemFont(ofSize: 12, weight: .medium)
@@ -100,13 +107,43 @@ final class ListTableViewCell: BaseTableViewCell {
         tagLabel.textColor = .systemBlue
     }
     
-    func configureData(_ data: Todo) {
-        title.text = data.title
+    internal func configureData(_ data: Todo) {
         content.text = data.content
         dateLabel.text = DateHelper.shared.string(from: data.dueDate)
         if let priorityInt = data.priority, let priorityEmoji = TodoPriority.init(rawValue: priorityInt)?.emoji {
             priority.text = priorityEmoji
         }
         tagLabel.text = data.tag
+        
+        setToggleButton(data)
+        setAttributeText(data)
+    }
+    
+    private func setToggleButton(_ data: Todo) {
+        guard var config = toggleButton.configuration else { return }
+        if data.completed {
+            config.image = UIImage(systemName: "checkmark.circle.fill")
+            toggleButton.configuration = config
+        } else {
+            config.image = UIImage(systemName: "circle")
+            toggleButton.configuration = config
+        }
+    }
+    
+    private func setAttributeText(_ data: Todo) {
+        let attributeString = NSMutableAttributedString(string: data.title)
+        attributeString.addAttribute(.foregroundColor, value: UIColor.white, range: NSMakeRange(0, attributeString.length))
+        
+        if data.completed {
+            attributeString.addAttribute(
+                .strikethroughStyle,
+                value: NSUnderlineStyle.single.rawValue,
+                range: NSMakeRange(
+                    0,
+                    attributeString.length
+                ))
+        }
+        
+        title.attributedText = attributeString
     }
 }

--- a/ReminderProject/ReminderProject/Views/ListView/ListTableViewCell.swift
+++ b/ReminderProject/ReminderProject/Views/ListView/ListTableViewCell.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 final class ListTableViewCell: BaseTableViewCell {
-    private let toggleButton = UIButton()
+    private(set) var toggleButton = UIButton()
     private let priority = UILabel()
     private let title = UILabel()
     private let content = UILabel()

--- a/ReminderProject/ReminderProject/Views/ListView/ListViewController.swift
+++ b/ReminderProject/ReminderProject/Views/ListView/ListViewController.swift
@@ -95,6 +95,21 @@ final class ListViewController: BaseViewController<ListView> {
         
         NavigationManager.shared.presentVC(ac, animated: true)
     }
+    
+    @objc
+    func toggleButtonTapped(_ sender: UIButton) {
+        let target = todos[sender.tag]
+        
+        RealmManager.shared.toggleCompleted(of: target)
+        
+        baseView.tableView.reloadRows(
+            at: [IndexPath(
+                row: sender.tag,
+                section: 0
+            )],
+            with: .automatic
+        )
+    }
 }
 
 extension ListViewController: UITableViewDelegate, UITableViewDataSource {
@@ -104,8 +119,13 @@ extension ListViewController: UITableViewDelegate, UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: ListTableViewCell.identifier, for: indexPath) as? ListTableViewCell else { return UITableViewCell() }
+        
         let data = todos[indexPath.row]
+        
+        cell.toggleButton.tag = indexPath.row
+        cell.toggleButton.addTarget(self, action: #selector(toggleButtonTapped), for: .touchUpInside)
         cell.configureData(data)
+        
         return cell
     }
     
@@ -125,7 +145,7 @@ extension ListViewController: UITableViewDelegate, UITableViewDataSource {
         let target = todos[indexPath.row]
         
         let flagedAction = UIContextualAction(style: .normal, title: "깃발") { [weak self] _, _, _ in
-            RealmManager.shared.updateFlaged(from: target)
+            RealmManager.shared.toggleFlaged(of: target)
             self?.delegate?.itemUpdated()
             UIView.animate(withDuration: 0.3) {
                 tableView.reloadData()

--- a/ReminderProject/ReminderProject/Views/ListView/ListViewController.swift
+++ b/ReminderProject/ReminderProject/Views/ListView/ListViewController.swift
@@ -18,15 +18,13 @@ final class ListViewController: BaseViewController<ListView> {
     )
     
     private var category: TodoCategory
-    private lazy var results = RealmManager.shared.readAll(Todo.self)
-        .where {
-            $0.tag == category.title
-        }
+    private var todos: Results<Todo>
     
     weak var delegate: ListViewControllerDelegate?
     
-    init(baseView: ListView, category: TodoCategory) {
+    init(baseView: ListView, category: TodoCategory, todos: Results<Todo>) {
         self.category = category
+        self.todos = todos
         super.init(baseView: baseView)
     }
     
@@ -58,11 +56,11 @@ final class ListViewController: BaseViewController<ListView> {
             title: "카테고리 순",
             style: .default
         ) {[weak self] _ in
-            if let results = self?.results.sorted(
+            if let todos = self?.todos.sorted(
                 byKeyPath: "category",
                 ascending: true
             ) {
-                self?.results = results
+                self?.todos = todos
                 self?.baseView.tableView.reloadData()
             }
         }
@@ -70,11 +68,11 @@ final class ListViewController: BaseViewController<ListView> {
             title: "이름 순",
             style: .default
         ) { [weak self] _ in
-            if let results = self?.results.sorted(
+            if let todos = self?.todos.sorted(
                 byKeyPath: "title",
                 ascending: true
             ) {
-                self?.results = results
+                self?.todos = todos
                 self?.baseView.tableView.reloadData()
             }
         }
@@ -82,11 +80,11 @@ final class ListViewController: BaseViewController<ListView> {
             title: "마감일 순",
             style: .default
         ) { [weak self] _ in
-            if let results = self?.results.sorted(
+            if let todos = self?.todos.sorted(
                 byKeyPath: "dueDate",
                 ascending: true
             ) {
-                self?.results = results
+                self?.todos = todos
                 self?.baseView.tableView.reloadData()
             }
         }
@@ -101,19 +99,19 @@ final class ListViewController: BaseViewController<ListView> {
 
 extension ListViewController: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return results.count
+        return todos.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: ListTableViewCell.identifier, for: indexPath) as? ListTableViewCell else { return UITableViewCell() }
-        let data = results[indexPath.row]
+        let data = todos[indexPath.row]
         cell.configureData(data)
         return cell
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: false)
-        let data = results[indexPath.row]
+        let data = todos[indexPath.row]
         
         NavigationManager.shared.pushVC(DetailTodoViewController(baseView: DetailTodoView(todo: data)))
     }
@@ -123,7 +121,7 @@ extension ListViewController: UITableViewDelegate, UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
-        let target = results[indexPath.row]
+        let target = todos[indexPath.row]
         
         let deleteAction = UIContextualAction(
             style: .destructive,

--- a/ReminderProject/ReminderProject/Views/ListView/ListViewController.swift
+++ b/ReminderProject/ReminderProject/Views/ListView/ListViewController.swift
@@ -109,6 +109,8 @@ final class ListViewController: BaseViewController<ListView> {
             )],
             with: .automatic
         )
+        
+        delegate?.itemUpdated()
     }
 }
 
@@ -147,7 +149,7 @@ extension ListViewController: UITableViewDelegate, UITableViewDataSource {
         let flagedAction = UIContextualAction(style: .normal, title: "깃발") { [weak self] _, _, _ in
             RealmManager.shared.toggleFlaged(of: target)
             self?.delegate?.itemUpdated()
-            UIView.animate(withDuration: 0.3) {
+            UIView.animate(withDuration: 0.2) {
                 tableView.reloadData()
             }
         }
@@ -158,7 +160,7 @@ extension ListViewController: UITableViewDelegate, UITableViewDataSource {
         ) { [weak self] _, _, _ in
             RealmManager.shared.delete(target)
             self?.delegate?.itemUpdated()
-            UIView.animate(withDuration: 0.3) {
+            UIView.animate(withDuration: 0.2) {
                 tableView.reloadData()
             }
         }

--- a/ReminderProject/ReminderProject/Views/ListView/ListViewController.swift
+++ b/ReminderProject/ReminderProject/Views/ListView/ListViewController.swift
@@ -124,9 +124,12 @@ extension ListViewController: UITableViewDelegate, UITableViewDataSource {
         
         let target = todos[indexPath.row]
         
-        let flagedAction = UIContextualAction(style: .normal, title: "깃발") { _, _, _ in
+        let flagedAction = UIContextualAction(style: .normal, title: "깃발") { [weak self] _, _, _ in
             RealmManager.shared.updateFlaged(from: target)
-            print(target)
+            self?.delegate?.itemUpdated()
+            UIView.animate(withDuration: 0.3) {
+                tableView.reloadData()
+            }
         }
         
         let deleteAction = UIContextualAction(
@@ -134,8 +137,10 @@ extension ListViewController: UITableViewDelegate, UITableViewDataSource {
             title: "삭제"
         ) { [weak self] _, _, _ in
             RealmManager.shared.delete(target)
-            tableView.reloadData()
-            self?.delegate?.deleteButtonTapped()
+            self?.delegate?.itemUpdated()
+            UIView.animate(withDuration: 0.3) {
+                tableView.reloadData()
+            }
         }
         
         return UISwipeActionsConfiguration(actions: [deleteAction, flagedAction])

--- a/ReminderProject/ReminderProject/Views/ListView/ListViewController.swift
+++ b/ReminderProject/ReminderProject/Views/ListView/ListViewController.swift
@@ -53,11 +53,11 @@ final class ListViewController: BaseViewController<ListView> {
             preferredStyle: .actionSheet
         )
         let dueDateSort = UIAlertAction(
-            title: "카테고리 순",
+            title: "우선순위 순",
             style: .default
         ) {[weak self] _ in
             if let todos = self?.todos.sorted(
-                byKeyPath: "category",
+                byKeyPath: "priority",
                 ascending: true
             ) {
                 self?.todos = todos
@@ -121,7 +121,13 @@ extension ListViewController: UITableViewDelegate, UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        
         let target = todos[indexPath.row]
+        
+        let flagedAction = UIContextualAction(style: .normal, title: "깃발") { _, _, _ in
+            RealmManager.shared.updateFlaged(from: target)
+            print(target)
+        }
         
         let deleteAction = UIContextualAction(
             style: .destructive,
@@ -132,6 +138,6 @@ extension ListViewController: UITableViewDelegate, UITableViewDataSource {
             self?.delegate?.deleteButtonTapped()
         }
         
-        return UISwipeActionsConfiguration(actions: [deleteAction])
+        return UISwipeActionsConfiguration(actions: [deleteAction, flagedAction])
     }
 }

--- a/ReminderProject/ReminderProject/Views/MainView/MainViewController.swift
+++ b/ReminderProject/ReminderProject/Views/MainView/MainViewController.swift
@@ -87,6 +87,14 @@ final class MainViewController: BaseViewController<MainView> {
             return $0.dueDate > currentDate
         }
         
+        flagedTodos = totalTodos.where {
+            $0.flaged == true
+        }
+        
+        completedTodos = totalTodos.where {
+            $0.completed == true
+        }
+        
         baseView.collectionView.reloadData()
     }
     
@@ -186,9 +194,8 @@ extension MainViewController: RegisterViewControllerDelegate {
 }
 
 extension MainViewController: ListViewControllerDelegate {
-    func deleteButtonTapped() {
+    func itemUpdated() {
         reloadData()
-        baseView.collectionView.reloadData()
     }
 }
 
@@ -200,5 +207,5 @@ extension MainViewController: CalendarAlertViewControllerDelegate {
 }
 
 protocol ListViewControllerDelegate: AnyObject {
-    func deleteButtonTapped()
+    func itemUpdated()
 }

--- a/ReminderProject/ReminderProject/Views/MainView/MainViewController.swift
+++ b/ReminderProject/ReminderProject/Views/MainView/MainViewController.swift
@@ -14,6 +14,7 @@ final class MainViewController: BaseViewController<MainView> {
     private var categories = TodoCategory.allCases
     private var currentDate = Date.now
     private var totalTodos: Results<Todo> = RealmManager.shared.readAll(Todo.self)
+    // https://stackoverflow.com/questions/35964884/how-do-i-filter-events-created-for-the-current-date-in-the-realm-swift/35965216#35965216
     private lazy var todayTodos = totalTodos.where {
         let start = Calendar.current.startOfDay(for: currentDate)
         if let end = Calendar.current.date(byAdding: .day, value: 1, to: start) {


### PR DESCRIPTION
## 🌱 *Pull requests*

🌿 **작업한 브랜치**
https://github.com/alpaka99/Reminder-Project/tree/%2322/Feat/Additional-ListView-Featrues

<br></br>

## 🔍 **작업한 결과**
- [x] 각 목록에 맞는 데이터를 filter 해서 보여줍니다
- [x] 제목, 메모, 마감일, 태그 우선순위 5가지 정보를 모두 보여줍니다
- [x] 왼쪽 동그라미 버튼을 누르면 할일이 완료됩니다
- [x] 우측 상단의 ... 버튼을 누르면 필터와 정렬이 가능합니다
- [x] 스와이프를 통해 삭제, 깃발, 핀고정 등의 기능을 구현합니다

<br></br>
## 🔫 **Trouble Shooting**
- Realm 데이터를 다시 꺼내오는게 퍼포먼스적으로 부정적이라 생각하여, MainViewController에서 ListViewController로 Results<Todo>를 직접 전달하려고 하였습니다. 이 방법이 가능하다 생각한 이유는 Results<Todo>는 라이브 데이터라, 한쪽의 변경사항이 일어나면, 이 객체를 참조하는 전체에 영향을 끼치는것으로 공식문서에서 확인했기 때문입니다. 
- 그래서 이전의 PR에 있는 코드에는 todayTodo와 scheduledTodo가 filter를 이용한 LazyFilterSequnce로 한번 더 래핑된 Results 타입이어서 다른 flagedTodo 혹은 completedTodo와 맞지 않았습니다.
- 이를 해결하는데에 너무나 오랜 시간이 걸렸지만, 다시 한번 Realm의 공식문서를 읽은 결과, where 안의 조건문을 결국에는 Predicate로 변환하는 과정을 Realm에서 브릿징 해주는것으로 알게 되었습니다. 따라서 ==, <, <= 등의 지정된 operator들로 where 문을 채워야한다는것을 깨달았습니다. 따라서 현재 where문을 이용하여 날짜를 통해 필터링을 하는 todayTodo와 scheduledTodo를 연산하는 방법을 변경하였습니다.
- 이를 통해 ListViewController의 초기화 과정에 Results<Todo> 타입을 일관적으로 전달해줄 수 있게 되었습니다 :)
```swift
private lazy var todayTodos = totalTodos.where {
        let start = Calendar.current.startOfDay(for: currentDate)
        if let end = Calendar.current.date(byAdding: .day, value: 1, to: start) {
            return $0.dueDate >= start && $0.dueDate < end
        }
        return $0.dueDate == Date.now
    }
    private lazy var scheduledTodos = totalTodos.where {
            return $0.dueDate > currentDate
    }
```

<br></br>
## 🔊 기타 공유사항
- 추후에 추가적으로 UISearchBar를 이용한 실시간 검색 기능을 구현해볼 수 있을 것 같습니다

<br></br>
## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|목록 화면 추가 기능 구현|![Simulator Screen Recording - iPhone 15 Pro - 2024-07-07 at 22 26 43](https://github.com/alpaka99/Reminder-Project/assets/22471820/967822b7-2f89-49ad-9d3d-ca0395b93919)|
<br></br>


## 📟 관련 이슈
- Resolved:  #22 
