### PR TITLE
#24/feat/categorize todo with new table

### DIFF
--- a/ReminderProject/ReminderProject.xcodeproj/project.pbxproj
+++ b/ReminderProject/ReminderProject.xcodeproj/project.pbxproj
@@ -51,6 +51,9 @@
 		CED1E12B2C392962004BFBE1 /* TodoPriority.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E12A2C392962004BFBE1 /* TodoPriority.swift */; };
 		CED1E12F2C398C42004BFBE1 /* FileManager+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E12E2C398C42004BFBE1 /* FileManager+Extension.swift */; };
 		CED1E1312C3A9882004BFBE1 /* Bool+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E1302C3A9882004BFBE1 /* Bool+Extension.swift */; };
+		CED1E13B2C3CB7EF004BFBE1 /* TodoSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E13A2C3CB7EF004BFBE1 /* TodoSearchView.swift */; };
+		CED1E13D2C3CB806004BFBE1 /* TodoSearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E13C2C3CB806004BFBE1 /* TodoSearchViewController.swift */; };
+		CED1E13F2C3CBB76004BFBE1 /* TodoSearchTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E13E2C3CBB76004BFBE1 /* TodoSearchTableViewCell.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -98,6 +101,9 @@
 		CED1E12A2C392962004BFBE1 /* TodoPriority.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoPriority.swift; sourceTree = "<group>"; };
 		CED1E12E2C398C42004BFBE1 /* FileManager+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+Extension.swift"; sourceTree = "<group>"; };
 		CED1E1302C3A9882004BFBE1 /* Bool+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bool+Extension.swift"; sourceTree = "<group>"; };
+		CED1E13A2C3CB7EF004BFBE1 /* TodoSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoSearchView.swift; sourceTree = "<group>"; };
+		CED1E13C2C3CB806004BFBE1 /* TodoSearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoSearchViewController.swift; sourceTree = "<group>"; };
+		CED1E13E2C3CBB76004BFBE1 /* TodoSearchTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoSearchTableViewCell.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -163,6 +169,7 @@
 		CED1E0952C33FA88004BFBE1 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				CED1E1392C3CB7A0004BFBE1 /* TodoSearchView */,
 				CED1E1252C384095004BFBE1 /* CalendarAlertView */,
 				CED1E0D92C360B89004BFBE1 /* DetailTodoView */,
 				CED1E0D42C35B13E004BFBE1 /* DetailInputView */,
@@ -291,6 +298,16 @@
 			path = CalendarAlertView;
 			sourceTree = "<group>";
 		};
+		CED1E1392C3CB7A0004BFBE1 /* TodoSearchView */ = {
+			isa = PBXGroup;
+			children = (
+				CED1E13A2C3CB7EF004BFBE1 /* TodoSearchView.swift */,
+				CED1E13C2C3CB806004BFBE1 /* TodoSearchViewController.swift */,
+				CED1E13E2C3CBB76004BFBE1 /* TodoSearchTableViewCell.swift */,
+			);
+			path = TodoSearchView;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -388,8 +405,10 @@
 				CED1E0C82C3497E2004BFBE1 /* ViewController+Extension.swift in Sources */,
 				CED1E0CF2C359FFC004BFBE1 /* Category.swift in Sources */,
 				CED1E0A42C3408D0004BFBE1 /* Reusable.swift in Sources */,
+				CED1E13D2C3CB806004BFBE1 /* TodoSearchViewController.swift in Sources */,
 				CED1E0B62C342DD1004BFBE1 /* RegisterOpenedCell.swift in Sources */,
 				CED1E0BD2C34596B004BFBE1 /* ListTableViewCell.swift in Sources */,
+				CED1E13F2C3CBB76004BFBE1 /* TodoSearchTableViewCell.swift in Sources */,
 				CED1E0C62C348920004BFBE1 /* Todo.swift in Sources */,
 				CED1E0D82C35C851004BFBE1 /* DateHelper.swift in Sources */,
 				CED1E0922C33F056004BFBE1 /* BaseView.swift in Sources */,
@@ -400,6 +419,7 @@
 				CED1E0CD2C356203004BFBE1 /* NSObject+Extension.swift in Sources */,
 				CED1E09D2C33FEF9004BFBE1 /* Constants.swift in Sources */,
 				CED1E0732C33E79C004BFBE1 /* AppDelegate.swift in Sources */,
+				CED1E13B2C3CB7EF004BFBE1 /* TodoSearchView.swift in Sources */,
 				CED1E1312C3A9882004BFBE1 /* Bool+Extension.swift in Sources */,
 				CED1E0B92C345386004BFBE1 /* ListViewController.swift in Sources */,
 				CED1E0D32C35B125004BFBE1 /* DetailInputViewController.swift in Sources */,

--- a/ReminderProject/ReminderProject/Extensions/UIColor+Extension.swift
+++ b/ReminderProject/ReminderProject/Extensions/UIColor+Extension.swift
@@ -26,4 +26,15 @@ extension UIColor {
         }
         return nil
     }
+    
+    func toHexString() -> String {
+            var r:CGFloat = 0
+            var g:CGFloat = 0
+            var b:CGFloat = 0
+            var a:CGFloat = 0
+            getRed(&r, green: &g, blue: &b, alpha: &a)
+            let rgb:Int = (Int)(r*255)<<16 | (Int)(g*255)<<8 | (Int)(b*255)<<0
+
+            return String(format:"#%06x", rgb)
+        }
 }

--- a/ReminderProject/ReminderProject/Managers/RealmManager.swift
+++ b/ReminderProject/ReminderProject/Managers/RealmManager.swift
@@ -101,4 +101,40 @@ final class RealmManager {
             print(error.localizedDescription)
         }
     }
+    
+    internal func addTodoToCategory(_ target: Todo, to category: Category) {
+        
+        
+        deleteTodoFromCategory(target)
+        
+        do {
+            try realm.write {
+                category.todos.append(target)
+            }
+        } catch {
+            print("Category set error")
+            print(error.localizedDescription)
+        }
+    }
+    
+    internal func deleteTodoFromCategory(_ target: Todo) {
+        
+            let categories = target.category
+            
+        categories.forEach { cat in
+            do {
+                try realm.write {
+                    for index in 0..<cat.todos.count {
+                        if target._id == cat.todos[index]._id {
+                            cat.todos.remove(at: index)
+                            return
+                        }
+                    }
+                }
+            } catch {
+                print("Deletion Error")
+                print(error)
+            }
+        }
+    }
 }

--- a/ReminderProject/ReminderProject/Models/RealmModels/Category.swift
+++ b/ReminderProject/ReminderProject/Models/RealmModels/Category.swift
@@ -12,8 +12,13 @@ final class Category: Object {
     @Persisted(primaryKey: true) var categoryName: String
     @Persisted var iconName: String
     @Persisted var backgroundColor: String
+    @Persisted var todos: List<Todo>
     
-    convenience init(categoryName: String, iconName: String, backgroundColor: String) {
+    convenience init(
+        categoryName: String,
+        iconName: String,
+        backgroundColor: String
+    ) {
         self.init()
         
         self.categoryName = categoryName

--- a/ReminderProject/ReminderProject/Models/RealmModels/Todo.swift
+++ b/ReminderProject/ReminderProject/Models/RealmModels/Todo.swift
@@ -21,6 +21,8 @@ final class Todo: Object {
     @Persisted var flaged: Bool = false
     @Persisted var completed: Bool = false
     
+    @Persisted(originProperty: "todos") var category: LinkingObjects<Category>
+    
     convenience init(
         title: String,
         content: String? = nil,

--- a/ReminderProject/ReminderProject/Views/ListView/ListView.swift
+++ b/ReminderProject/ReminderProject/Views/ListView/ListView.swift
@@ -47,7 +47,7 @@ final class ListView: BaseView {
         }
     }
     
-    func configureData(_ data: TodoCategory) {
-        titleLabel.text = data.title
+    func configureData(_ text: String) {
+        titleLabel.text = text
     }
 }

--- a/ReminderProject/ReminderProject/Views/ListView/ListViewController.swift
+++ b/ReminderProject/ReminderProject/Views/ListView/ListViewController.swift
@@ -19,6 +19,7 @@ final class ListViewController: BaseViewController<ListView> {
     
     private var category: TodoCategory
     private var todos: Results<Todo>
+    private var userCategories = RealmManager.shared.readAll(Category.self)
     
     weak var delegate: ListViewControllerDelegate?
     
@@ -166,5 +167,25 @@ extension ListViewController: UITableViewDelegate, UITableViewDataSource {
         }
         
         return UISwipeActionsConfiguration(actions: [deleteAction, flagedAction])
+    }
+    
+    func tableView(_ tableView: UITableView, contextMenuConfigurationForRowAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration? {
+        
+        let target = todos[indexPath.row]
+        
+        return UIContextMenuConfiguration(identifier: nil, previewProvider: nil, actionProvider: { [weak self] _ in
+            
+            var actions: [UIAction] = []
+            
+            self?.userCategories.forEach { userCategory in
+                let action = UIAction(title: userCategory.categoryName) {_ in
+                    RealmManager.shared.addTodoToCategory(target, to: userCategory)
+                }
+                
+                actions.append(action)
+            }
+            
+            return UIMenu(title: "해당 카테고리로 이동", children: actions)
+        })
     }
 }

--- a/ReminderProject/ReminderProject/Views/ListView/ListViewController.swift
+++ b/ReminderProject/ReminderProject/Views/ListView/ListViewController.swift
@@ -17,14 +17,14 @@ final class ListViewController: BaseViewController<ListView> {
         action: #selector(rightBarButtonTapped)
     )
     
-    private var category: TodoCategory
-    private var todos: Results<Todo>
+    private var categoryTitle: String
+    private var todos: [Todo]
     private var userCategories = RealmManager.shared.readAll(Category.self)
     
     weak var delegate: ListViewControllerDelegate?
     
-    init(baseView: ListView, category: TodoCategory, todos: Results<Todo>) {
-        self.category = category
+    init(baseView: ListView, categoryTitle: String, todos: [Todo]) {
+        self.categoryTitle = categoryTitle
         self.todos = todos
         super.init(baseView: baseView)
     }
@@ -33,7 +33,7 @@ final class ListViewController: BaseViewController<ListView> {
         super.configureUI()
         
         navigationItem.rightBarButtonItem = rightBarbutton
-        baseView.configureData(category)
+        baseView.configureData(categoryTitle)
     }
     
     override func configureDelegate() {
@@ -57,11 +57,8 @@ final class ListViewController: BaseViewController<ListView> {
             title: "우선순위 순",
             style: .default
         ) {[weak self] _ in
-            if let todos = self?.todos.sorted(
-                byKeyPath: "priority",
-                ascending: true
-            ) {
-                self?.todos = todos
+            if let todos = self?.todos {
+                self?.todos = todos.sorted(by: {$0.priority ?? 0 < $1.priority ?? 0})
                 self?.baseView.tableView.reloadData()
             }
         }
@@ -69,11 +66,8 @@ final class ListViewController: BaseViewController<ListView> {
             title: "이름 순",
             style: .default
         ) { [weak self] _ in
-            if let todos = self?.todos.sorted(
-                byKeyPath: "title",
-                ascending: true
-            ) {
-                self?.todos = todos
+            if let todos = self?.todos {
+                self?.todos = todos.sorted(by: { $0.title < $1.title })
                 self?.baseView.tableView.reloadData()
             }
         }
@@ -81,11 +75,8 @@ final class ListViewController: BaseViewController<ListView> {
             title: "마감일 순",
             style: .default
         ) { [weak self] _ in
-            if let todos = self?.todos.sorted(
-                byKeyPath: "dueDate",
-                ascending: true
-            ) {
-                self?.todos = todos
+            if let todos = self?.todos {
+                self?.todos = todos.sorted(by: { $0.dueDate ?? Date() < $1.dueDate ?? Date()})
                 self?.baseView.tableView.reloadData()
             }
         }
@@ -180,12 +171,18 @@ extension ListViewController: UITableViewDelegate, UITableViewDataSource {
             self?.userCategories.forEach { userCategory in
                 let action = UIAction(title: userCategory.categoryName) {_ in
                     RealmManager.shared.addTodoToCategory(target, to: userCategory)
+                    
+                    UIView.animate(withDuration: 0.2) {
+                        
+                        tableView.reloadData()
+                        self?.delegate?.itemUpdated()
+                    }
                 }
                 
                 actions.append(action)
             }
             
-            return UIMenu(title: "해당 카테고리로 이동", children: actions)
+            return UIMenu(title: "해당 카테고리로 분류", children: actions)
         })
     }
 }

--- a/ReminderProject/ReminderProject/Views/MainView/MainViewController.swift
+++ b/ReminderProject/ReminderProject/Views/MainView/MainViewController.swift
@@ -120,7 +120,7 @@ final class MainViewController: BaseViewController<MainView> {
     func rightBarButtonTapped() {
         let todoSearchViewController = TodoSearchViewController(baseView: TodoSearchView())
         
-        NavigationManager.shared.presentVC(todoSearchViewController, animated: true)
+        NavigationManager.shared.pushVC(todoSearchViewController, animated: true)
     }
     
     
@@ -131,7 +131,7 @@ final class MainViewController: BaseViewController<MainView> {
         registerViewController.delegate = self
         
         let navigationController = UINavigationController(rootViewController: registerViewController)
-        NavigationManager.shared.pushVC(navigationController, animated: true)
+        NavigationManager.shared.presentVC(navigationController, animated: true)
     }
     
     @objc

--- a/ReminderProject/ReminderProject/Views/MainView/MainViewController.swift
+++ b/ReminderProject/ReminderProject/Views/MainView/MainViewController.swift
@@ -70,6 +70,8 @@ final class MainViewController: BaseViewController<MainView> {
             action: #selector(newTodoButtonTapped),
             for: .touchUpInside
         )
+        
+        baseView.addListButton.addTarget(self, action: #selector(addListButtonTapped), for: .touchUpInside)
     }
     
     func reloadData() {
@@ -108,7 +110,8 @@ final class MainViewController: BaseViewController<MainView> {
         NavigationManager.shared.presentVC(calendarAlertViewController, animated: true)
     }
     
-    @objc func rightBarButtonTapped() {
+    @objc 
+    func rightBarButtonTapped() {
         
     }
     
@@ -121,6 +124,51 @@ final class MainViewController: BaseViewController<MainView> {
         
         let navigationController = UINavigationController(rootViewController: registerViewController)
         NavigationManager.shared.presentVC(navigationController)
+    }
+    
+    @objc
+    func addListButtonTapped(_ sender: UIButton) {
+        let ac = UIAlertController(
+            title: "새로운 카테고리",
+            message: "여러분만의 카테고리를 만들어주세요",
+            preferredStyle: .alert
+        )
+        ac.addTextField { [weak self] textField in
+            textField.placeholder = "카테고리 이름을 입력해주세요"
+            textField.addTarget(
+                self,
+                action: #selector(self?.textFieldSubmitted),
+                for: .editingDidEndOnExit
+            )
+        }
+        
+        let cancelAction = UIAlertAction(
+            title: "취소",
+            style: .cancel
+        ) { _ in
+            print("cancel")
+        }
+        ac.addAction(cancelAction)
+        
+        let conformAction = UIAlertAction(
+            title: "확인",
+            style: .default
+        ) { [weak self] _ in
+            if let textField = ac.textFields?.first {
+                self?.textFieldSubmitted(textField)
+            }
+            print("conform")
+        }
+        ac.addAction(conformAction)
+        
+        
+        present(ac, animated: true)
+    }
+    
+    @objc
+    func textFieldSubmitted(_ sender: UITextField) {
+        
+        
     }
 }
 

--- a/ReminderProject/ReminderProject/Views/MainView/MainViewController.swift
+++ b/ReminderProject/ReminderProject/Views/MainView/MainViewController.swift
@@ -44,7 +44,7 @@ final class MainViewController: BaseViewController<MainView> {
     )
     
     private lazy var rightBarbutton = UIBarButtonItem(
-        image: UIImage(systemName: "ellipsis.circle"),
+        image: UIImage(systemName: "list.bullet"),
         style: .plain,
         target: self,
         action: #selector(rightBarButtonTapped)
@@ -118,7 +118,9 @@ final class MainViewController: BaseViewController<MainView> {
     
     @objc 
     func rightBarButtonTapped() {
+        let todoSearchViewController = TodoSearchViewController(baseView: TodoSearchView())
         
+        NavigationManager.shared.presentVC(todoSearchViewController, animated: true)
     }
     
     
@@ -129,7 +131,7 @@ final class MainViewController: BaseViewController<MainView> {
         registerViewController.delegate = self
         
         let navigationController = UINavigationController(rootViewController: registerViewController)
-        NavigationManager.shared.presentVC(navigationController)
+        NavigationManager.shared.pushVC(navigationController, animated: true)
     }
     
     @objc
@@ -228,7 +230,7 @@ extension MainViewController: UICollectionViewDelegate, UICollectionViewDataSour
             let type = userCategories[indexPath.row]
             
             cell.title.text = type.categoryName
-            cell.icon.image = UIImage(systemName: type.iconName)
+            cell.icon.image = UIImage(systemName: type.iconName)?.withTintColor(.white)
             cell.iconBackground.backgroundColor = UIColor.hexToColor(type.backgroundColor)
             
             let count = type.todos.count

--- a/ReminderProject/ReminderProject/Views/TodoSearchView/TodoSearchTableViewCell.swift
+++ b/ReminderProject/ReminderProject/Views/TodoSearchView/TodoSearchTableViewCell.swift
@@ -1,0 +1,45 @@
+//
+//  TodoSearchTableViewCell.swift
+//  ReminderProject
+//
+//  Created by user on 7/9/24.
+//
+
+import UIKit
+
+import SnapKit
+
+final class TodoSearchTableViewCell: BaseTableViewCell {
+    let titleLabel = {
+        let label = UILabel()
+        
+        return label
+    }()
+    
+    let subTitleLabel = {
+        let label = UILabel()
+        
+        return label
+    }()
+    
+    override func configureHierarchy() {
+        super.configureHierarchy()
+        
+        contentView.addSubview(titleLabel)
+        contentView.addSubview(subTitleLabel)
+    }
+    
+    override func configureLayout() {
+        super.configureLayout()
+        
+        titleLabel.snp.makeConstraints {
+            $0.leading.equalTo(contentView.snp.leading)
+                .offset(16)
+        }
+        
+        subTitleLabel.snp.makeConstraints {
+            $0.trailing.equalTo(contentView.snp.trailing)
+                .offset(-16)
+        }
+    }
+}

--- a/ReminderProject/ReminderProject/Views/TodoSearchView/TodoSearchView.swift
+++ b/ReminderProject/ReminderProject/Views/TodoSearchView/TodoSearchView.swift
@@ -1,0 +1,39 @@
+//
+//  TodoSearchView.swift
+//  ReminderProject
+//
+//  Created by user on 7/9/24.
+//
+
+import UIKit
+
+import SnapKit
+
+final class TodoSearchView: BaseView {
+    let searchBar = UISearchBar()
+    let tableView = UITableView()
+    
+    override func configureHierarchy() {
+        super.configureHierarchy()
+        
+        self.addSubview(searchBar)
+        self.addSubview(tableView)
+    }
+    
+    override func configureLayout() {
+        super.configureLayout()
+        
+        searchBar.snp.makeConstraints {
+            $0.top.horizontalEdges.equalTo(self.safeAreaLayoutGuide)
+        }
+        
+        tableView.snp.makeConstraints {
+            $0.top.equalTo(searchBar.snp.bottom)
+            $0.horizontalEdges.bottom.equalTo(self.safeAreaLayoutGuide)
+        }
+    }
+    
+    override func configureUI() {
+        super.configureUI()
+    }
+}

--- a/ReminderProject/ReminderProject/Views/TodoSearchView/TodoSearchViewController.swift
+++ b/ReminderProject/ReminderProject/Views/TodoSearchView/TodoSearchViewController.swift
@@ -1,0 +1,49 @@
+//
+//  TodoSearchViewController.swift
+//  ReminderProject
+//
+//  Created by user on 7/9/24.
+//
+
+import UIKit
+
+final class TodoSearchViewController: BaseViewController<TodoSearchView> {
+    
+    let todos = RealmManager.shared.readAll(Todo.self)
+    
+    override func configureDelegate() {
+        super.configureDelegate()
+        
+        baseView.searchBar.delegate = self
+        
+        baseView.tableView.delegate = self
+        baseView.tableView.dataSource = self
+        baseView.tableView.register(UITableViewCell.self, forCellReuseIdentifier: UITableViewCell.identifier)
+        baseView.tableView.register(TodoSearchTableViewCell.self, forCellReuseIdentifier: TodoSearchTableViewCell.identifier)
+    }
+}
+
+extension TodoSearchViewController: UISearchBarDelegate {
+    
+}
+
+
+extension TodoSearchViewController: UITableViewDelegate, UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return todos.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: TodoSearchTableViewCell.identifier, for: indexPath) as? TodoSearchTableViewCell else { return UITableViewCell() }
+        
+        let data = todos[indexPath.row]
+        
+        cell.titleLabel.text = data.title
+        
+        cell.subTitleLabel.text = data.category.first?.categoryName
+        
+        return cell
+    }
+    
+    
+}


### PR DESCRIPTION
## 🌱 *Pull requests*

🌿 **작업한 브랜치**
https://github.com/alpaka99/Reminder-Project/tree/%2324/Feat/Categorize-Todo-with-New-Table

<br></br>

## 🔍 **작업한 결과**
- [x] 저장되어있는 Todo들을 분류하여 저장할 수 있도록 새로운 분류 기준을 만듭니다
- [x] 분류기준을 이용해서 저장된 todo들을 나눠서 보여줄 수 있게 해줍니다

<br></br>
## 🔫 **Trouble Shooting**
- 기존 카테고리들은 전부 다 연산을 통해서 분류하는 카테고리고, 새로 도입하려는 사용자가 생성하는 카테고리는 Category라는 Realm Table을 이용하는 카테고리여서 고민을 많이 했습니다. 결국 MainViewController의 섹션을 나눠서 section0에는 기존의 연산하는 카테고리, section1에는 사용자 지정 카테고리가 보이도록 하였습니다.
- 목록 추가 버튼을 통해 사용자가 카테고리를 스스로 추가할 수 있도록 하였습니다. 또한 이 갯수가 무한대로 늘어날 수 있음에 따라, 어떻게 하면 todo 아이템을 잘 이동시킬 수 있을지 고민을 했습니다. 고민한 결과 UIMenu를 이용하여 옮길 수 있게 하는게 효과적이라 생각하여 기존의 ListViewController에 UIMenu를 구현하여 사용자 정의 카테고리를 보고 todo를 이동시킬 수 있게 하였습니다.
- #19 에서 적어놓은 Result type을 이용하던 MainViewController가 결국에는 Swift Array를 사용하게 되었습니다. 이는 하단에서 설명할 Realm의 List 타입을 다시 Result 타입으로 되돌리기가 굉장히 어렵기 때문입니다. 그래서 통일 시킬 수 있는 Swift Array 타입을 이용하기로 판단하였습니다.
- CategoryTable-Todo가 One-To-Many 관계가 될 수 있도록 관계를 설정하였습니다. Category 테이블 안에 Todos라는 column을 만들어 todo들과의 관계 설정을 할 수 있게 하였고, todo에는 LinkedObjects 타입을 이용하여 Category를 역참조 가능하게 만들었습니다. Todos Column은 Realm의 List 타입이기 때문에 사용할 때 여러가지 타입이 혼재될 가능성이 있어서, Swift Array 타입으로 전부 변환하여 사용중입니다.
<br></br>
## 🔊 기타 공유사항


<br></br>
## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|사용자 설정 카테고리 생성|![Simulator Screen Recording - iPhone 15 Pro - 2024-07-10 at 01 35 32](https://github.com/alpaka99/Reminder-Project/assets/22471820/8669968f-0976-4476-bfc7-c69f03101856)|
|UIMenu를 이용한 Category-Todo 관계 설정|![Simulator Screen Recording - iPhone 15 Pro - 2024-07-10 at 01 34 49](https://github.com/alpaka99/Reminder-Project/assets/22471820/e5173404-a527-4df5-91ae-ef2f0d819680)|

## 📟 관련 이슈
- Resolved: #24 
