### PR TITLE
#26/refactor/implement view model

### DIFF
--- a/ReminderProject/ReminderProject.xcodeproj/project.pbxproj
+++ b/ReminderProject/ReminderProject.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		CED1E13B2C3CB7EF004BFBE1 /* TodoSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E13A2C3CB7EF004BFBE1 /* TodoSearchView.swift */; };
 		CED1E13D2C3CB806004BFBE1 /* TodoSearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E13C2C3CB806004BFBE1 /* TodoSearchViewController.swift */; };
 		CED1E13F2C3CBB76004BFBE1 /* TodoSearchTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E13E2C3CBB76004BFBE1 /* TodoSearchTableViewCell.swift */; };
+		CED1E1592C3DA8C1004BFBE1 /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E1582C3DA8C1004BFBE1 /* Observable.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -104,6 +105,7 @@
 		CED1E13A2C3CB7EF004BFBE1 /* TodoSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoSearchView.swift; sourceTree = "<group>"; };
 		CED1E13C2C3CB806004BFBE1 /* TodoSearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoSearchViewController.swift; sourceTree = "<group>"; };
 		CED1E13E2C3CBB76004BFBE1 /* TodoSearchTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoSearchTableViewCell.swift; sourceTree = "<group>"; };
+		CED1E1582C3DA8C1004BFBE1 /* Observable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Observable.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -162,6 +164,7 @@
 				CED1E0912C33F056004BFBE1 /* BaseView.swift */,
 				CED1E0A02C3405A9004BFBE1 /* BaseCollectionViewCell.swift */,
 				CED1E0B32C341ED3004BFBE1 /* BaseTableViewCell.swift */,
+				CED1E1582C3DA8C1004BFBE1 /* Observable.swift */,
 			);
 			path = Bases;
 			sourceTree = "<group>";
@@ -407,6 +410,7 @@
 				CED1E0A42C3408D0004BFBE1 /* Reusable.swift in Sources */,
 				CED1E13D2C3CB806004BFBE1 /* TodoSearchViewController.swift in Sources */,
 				CED1E0B62C342DD1004BFBE1 /* RegisterOpenedCell.swift in Sources */,
+				CED1E1592C3DA8C1004BFBE1 /* Observable.swift in Sources */,
 				CED1E0BD2C34596B004BFBE1 /* ListTableViewCell.swift in Sources */,
 				CED1E13F2C3CBB76004BFBE1 /* TodoSearchTableViewCell.swift in Sources */,
 				CED1E0C62C348920004BFBE1 /* Todo.swift in Sources */,

--- a/ReminderProject/ReminderProject.xcodeproj/project.pbxproj
+++ b/ReminderProject/ReminderProject.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		CED1E13D2C3CB806004BFBE1 /* TodoSearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E13C2C3CB806004BFBE1 /* TodoSearchViewController.swift */; };
 		CED1E13F2C3CBB76004BFBE1 /* TodoSearchTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E13E2C3CBB76004BFBE1 /* TodoSearchTableViewCell.swift */; };
 		CED1E1592C3DA8C1004BFBE1 /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E1582C3DA8C1004BFBE1 /* Observable.swift */; };
+		CED1E1812C3DCC9A004BFBE1 /* RegisterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E1802C3DCC9A004BFBE1 /* RegisterViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -106,6 +107,7 @@
 		CED1E13C2C3CB806004BFBE1 /* TodoSearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoSearchViewController.swift; sourceTree = "<group>"; };
 		CED1E13E2C3CBB76004BFBE1 /* TodoSearchTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoSearchTableViewCell.swift; sourceTree = "<group>"; };
 		CED1E1582C3DA8C1004BFBE1 /* Observable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Observable.swift; sourceTree = "<group>"; };
+		CED1E1802C3DCC9A004BFBE1 /* RegisterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -234,6 +236,7 @@
 				CED1E0AD2C34156B004BFBE1 /* RegisterView.swift */,
 				CED1E0AF2C341CDC004BFBE1 /* RegisterDisclosureCell.swift */,
 				CED1E0B52C342DD1004BFBE1 /* RegisterOpenedCell.swift */,
+				CED1E1802C3DCC9A004BFBE1 /* RegisterViewModel.swift */,
 			);
 			path = RegisterView;
 			sourceTree = "<group>";
@@ -405,6 +408,7 @@
 				CED1E0A12C3405A9004BFBE1 /* BaseCollectionViewCell.swift in Sources */,
 				CED1E0AE2C34156B004BFBE1 /* RegisterView.swift in Sources */,
 				CED1E0902C33EFE5004BFBE1 /* BaseViewController.swift in Sources */,
+				CED1E1812C3DCC9A004BFBE1 /* RegisterViewModel.swift in Sources */,
 				CED1E0C82C3497E2004BFBE1 /* ViewController+Extension.swift in Sources */,
 				CED1E0CF2C359FFC004BFBE1 /* Category.swift in Sources */,
 				CED1E0A42C3408D0004BFBE1 /* Reusable.swift in Sources */,

--- a/ReminderProject/ReminderProject/Bases/Observable.swift
+++ b/ReminderProject/ReminderProject/Bases/Observable.swift
@@ -1,0 +1,28 @@
+//
+//  Observable.swift
+//  ReminderProject
+//
+//  Created by user on 7/10/24.
+//
+
+import Foundation
+
+final class Observable<T> {
+    
+    var closure: ((T) -> Void)?
+    
+    var value: T
+    
+    init(_ value: T) {
+        self.value = value
+    }
+    
+    func bind(_ closure: @escaping (T)->Void) {
+        self.closure = closure
+    }
+    
+    func actionClosure(_ closure: @escaping (T)->Void) {
+        closure(value)
+        self.closure = closure
+    }
+}

--- a/ReminderProject/ReminderProject/Bases/Observable.swift
+++ b/ReminderProject/ReminderProject/Bases/Observable.swift
@@ -11,7 +11,11 @@ final class Observable<T> {
     
     var closure: ((T) -> Void)?
     
-    var value: T
+    var value: T {
+        didSet {
+            closure?(value)
+        }
+    }
     
     init(_ value: T) {
         self.value = value

--- a/ReminderProject/ReminderProject/Views/DetailInputView/DetailInputViewController.swift
+++ b/ReminderProject/ReminderProject/Views/DetailInputView/DetailInputViewController.swift
@@ -17,7 +17,6 @@ final class DetailInputViewController: BaseViewController<DetailInputView> {
         
         guard let type = type else { return }
         
-        
         let detailData = baseView.sendDetailData()
         
         delegate?.sendDetailData(type, text: detailData)

--- a/ReminderProject/ReminderProject/Views/RegisterView/RegisterViewModel.swift
+++ b/ReminderProject/ReminderProject/Views/RegisterView/RegisterViewModel.swift
@@ -1,0 +1,23 @@
+//
+//  RegisterViewModel.swift
+//  ReminderProject
+//
+//  Created by user on 7/10/24.
+//
+
+import Foundation
+
+final class RegisterViewModel {
+    let registerFieldTypes: [RegisterFieldType] = RegisterFieldType.allCases
+    
+    var inputTitle = Observable("")
+    var inputContent: Observable<String?> = Observable("")
+    var inputDate = Observable("")
+    var inputTag = Observable("")
+    var inputPriority = Observable("")
+    var inputImage: Observable<Data?> = Observable(Data())
+    var inputDetailInputType = Observable(RegisterFieldType.dueDate)
+    
+    var inputCancelButtonTapped: Observable<Void?> = Observable(())
+    var addButtonTapped: Observable<Void?> = Observable(())
+}


### PR DESCRIPTION
## 🌱 *Pull requests*

🌿 **작업한 브랜치**
https://github.com/alpaka99/Reminder-Project/tree/%2326/Refactor/Implement-ViewModel

<br></br>

## 🔍 **작업한 결과**
- [x] RegisterViewController로부터 비즈니스 로직을 분리하여 ViewModel을 생성하기
- [x] ViewModel이 반응형이 될 수 있도록 Observable 객체를 정의하여 wrapping하기

<br></br>
## 🔫 **Trouble Shooting**
- Observable 객체를 직접 만들면서 실수 했던 부분이 value의 didSet을 설정해주지 않아 closure가 실행되지 않는 부분이었습니다. bindData() 메서드는 실행되는데 클로저가 실행되지 않아 약간을 헤맸지만 알맞게 수정하였습니다.
```swift
var value: T {
    didSet {
        closure?()
    }
}
```
- 아직 완벽하게 분리해내지 못한 느낌이라 약간은 아쉽습니다. 예를 들어 PHPickerDelegate의 부분의 로직을 현재는 결과값인 image만 data로 전달받고 있는데, 저 메서드의 if let 구문등의 로직을 전부 다 view model 안으로 옮길 수 없을까 생각해볼 수 있겠습니다. 또한 다른 여러 if-let 구문과 연산들이 아직 viewController안에 남아있는 느낌이 들었습니다.
- ViewModel은 순수하게 비즈니스 로직만 갖고 있기 위해 다른 프레임워크는 import 해주지 않고 있는데, 어디까지 엄격하게 이 기준을 적용해야하는지 스스로 기준을 세워야겠다고 생각했습니다.

<br></br>
## 🔊 기타 공유사항
- 추후에 더 많은 ViewModel들이 생겨나면, ViewController마다 bindData()가 호출되어야하므로, baseViewController에 미리 추상타입을 만들어놓고 baseViewController의 viewDidLoad()에서 미리 호출시켜놓는 방법도 좋을것 같습니다.
- 현재는 ViewModel 내부의 메서드들만 private 접근제어자를 붙히는 규약이 있지만, 추후에는 모델도 private 처리를 할 수 있는 방법을 생각중입니다.

<br></br>
## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
| ViewModel로 동작하는 RegisterView |![Simulator Screen Recording - iPhone 15 Pro - 2024-07-10 at 04 58 06](https://github.com/alpaka99/Reminder-Project/assets/22471820/84fe08de-abdb-45b7-90d4-cae82a8e783f)|
<br></br>

## 📟 관련 이슈
- Resolved: #26 
